### PR TITLE
transforms: add convert-qref-to-qssa

### DIFF
--- a/inconspiquous/transforms/__init__.py
+++ b/inconspiquous/transforms/__init__.py
@@ -11,6 +11,11 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return canonicalize.CanonicalizePass
 
+    def get_convert_qref_to_qssa():
+        from inconspiquous.transforms import convert_qref_to_qssa
+
+        return convert_qref_to_qssa.ConvertQrefToQssa
+
     def get_convert_qssa_to_qref():
         from inconspiquous.transforms import convert_qssa_to_qref
 
@@ -73,6 +78,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
     return {
         "canonicalize": get_canonicalize,
+        "convert-qref-to-qssa": get_convert_qref_to_qssa,
         "convert-qssa-to-qref": get_convert_qssa_to_qref,
         "convert-scf-to-cf": get_convert_scf_to_cf,
         "convert-to-xzs": get_convert_to_xzs,

--- a/inconspiquous/transforms/convert_qref_to_qssa.py
+++ b/inconspiquous/transforms/convert_qref_to_qssa.py
@@ -1,0 +1,83 @@
+from xdsl.dialects import builtin
+from xdsl.parser import MLContext
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    GreedyRewritePatternApplier,
+    PatternRewriteWalker,
+    PatternRewriter,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+
+from inconspiquous.dialects import qref, qssa
+
+
+class ConvertQrefGateToQssaGate(RewritePattern):
+    """
+    Replaces a qssa gate operation by its qref counterpart.
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(
+        self, op: qref.GateOp | qref.DynGateOp, rewriter: PatternRewriter
+    ):
+        # Don't rewrite if uses live in different blocks
+        if op.parent_block() is None:
+            return
+        for operand in op.ins:
+            for use in operand.uses:
+                if use.operation.parent_block() != op.parent_block():
+                    return
+
+        if isinstance(op, qref.GateOp):
+            new_op = qssa.GateOp(op.gate, *op.ins)
+        else:
+            new_op = qssa.DynGateOp(op.gate, *op.ins)
+
+        rewriter.replace_matched_op(new_op, ())
+
+        for operand, result in zip(op.ins, new_op.results):
+            operand.replace_by_if(result, lambda use: use.operation is not new_op)
+
+
+class ConvertQrefMeasureToQssaMeasure(RewritePattern):
+    """
+    Replaces a qssa measurement by its qref counterpart.
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: qref.MeasureOp, rewriter: PatternRewriter):
+        # Don't rewrite if uses live in different blocks
+        if op.parent_block() is None:
+            return
+        for use in op.in_qubit.uses:
+            if use.operation.parent_block() != op.parent_block():
+                return
+
+        new_op = qssa.MeasureOp(op.in_qubit)
+
+        rewriter.replace_matched_op(new_op, (op.out,))
+
+        op.in_qubit.replace_by_if(
+            new_op.out_qubit, lambda use: use.operation is not new_op
+        )
+
+
+class ConvertQrefToQssa(ModulePass):
+    """
+    Converts uses of the qssa dialect to the qref dialect in a module.
+    Inverse to the "convert-qref-to-qssa" pass.
+    """
+
+    name = "convert-qref-to-qssa"
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
+        PatternRewriteWalker(
+            GreedyRewritePatternApplier(
+                [
+                    ConvertQrefGateToQssaGate(),
+                    ConvertQrefMeasureToQssaMeasure(),
+                ]
+            ),
+            apply_recursively=False,
+        ).rewrite_module(op)

--- a/tests/filecheck/transforms/convert_qref_to_qssa.mlir
+++ b/tests/filecheck/transforms/convert_qref_to_qssa.mlir
@@ -1,0 +1,51 @@
+// RUN: quopt -p convert-qref-to-qssa %s | filecheck %s
+// RUN: quopt -p convert-qref-to-qssa,convert-qssa-to-qref %s | filecheck %s --check-prefix=CHECK-ROUNDTRIP
+
+%q0 = qubit.alloc
+%q1 = qubit.alloc
+qref.gate<#gate.h> %q0
+qref.gate<#gate.rz<0.5pi>> %q1
+qref.gate<#gate.cnot> %q0, %q1
+%0 = qref.measure %q0
+%g = gate.constant #gate.h
+qref.dyn_gate<%g> %q0 : !qubit.bit
+%1 = qref.measure %q0
+
+// CHECK:      %q0 = qubit.alloc
+// CHECK-NEXT: %q1 = qubit.alloc
+// CHECK-NEXT: %q0_1 = qssa.gate<#gate.h> %q0
+// CHECK-NEXT: %q1_1 = qssa.gate<#gate.rz<0.5pi>> %q1
+// CHECK-NEXT: %q0_2, %q1_2 = qssa.gate<#gate.cnot> %q0_1, %q1_1
+// CHECK-NEXT: %{{.*}}, %q0_3 = qssa.measure %q0_2
+// CHECK-NEXT: %g = gate.constant #gate.h
+// CHECK-NEXT: %q0_4 = qssa.dyn_gate<%g> %q0_3 : !qubit.bit
+// CHECK-NEXT: %{{.*}}, %q0_5 = qssa.measure %q0_4
+
+// CHECK-ROUNDTRIP:      %q0 = qubit.alloc
+// CHECK-ROUNDTRIP-NEXT: %q1 = qubit.alloc
+// CHECK-ROUNDTRIP-NEXT: qref.gate<#gate.h> %q0
+// CHECK-ROUNDTRIP-NEXT: qref.gate<#gate.rz<0.5pi>> %q1
+// CHECK-ROUNDTRIP-NEXT: qref.gate<#gate.cnot> %q0, %q1
+// CHECK-ROUNDTRIP-NEXT: %{{.*}} = qref.measure %q0
+// CHECK-ROUNDTRIP-NEXT: %g = gate.constant #gate.h
+// CHECK-ROUNDTRIP-NEXT: qref.dyn_gate<%g> %q0 : !qubit.bit
+// CHECK-ROUNDTRIP-NEXT: %{{.*}} = qref.measure %q0
+
+func.func @qref_in_region(%q : !qubit.bit, %p: i1) -> !qubit.bit {
+  %q2 = scf.if %p -> (!qubit.bit) {
+    qref.gate<#gate.z> %q
+    scf.yield %q : !qubit.bit
+  } else {
+    scf.yield %q : !qubit.bit
+  }
+  func.return %q2 : !qubit.bit
+}
+
+// CHECK:      func.func @qref_in_region
+// CHECK-NEXT: %q2 = scf.if %p -> (!qubit.bit) {
+// CHECK-NEXT:   qref.gate<#gate.z> %q
+// CHECK-NEXT:   scf.yield %q : !qubit.bit
+// CHECK-NEXT: } else {
+// CHECK-NEXT:   scf.yield %q : !qubit.bit
+// CHECK-NEXT: }
+// CHECK-NEXT: func.return %q2 : !qubit.bit

--- a/tests/filecheck/transforms/convert_qssa_to_qref.mlir
+++ b/tests/filecheck/transforms/convert_qssa_to_qref.mlir
@@ -1,4 +1,5 @@
 // RUN: quopt -p convert-qssa-to-qref %s | filecheck %s
+// RUN: quopt -p convert-qssa-to-qref,convert-qref-to-qssa %s | filecheck %s --check-prefix=CHECK-ROUNDTRIP
 
 %q0 = qubit.alloc
 %q1 = qubit.alloc
@@ -19,3 +20,13 @@
 // CHECK-NEXT: %g = gate.constant #gate.h
 // CHECK-NEXT: qref.dyn_gate<%g> %q0 : !qubit.bit
 // CHECK-NEXT: %{{.*}} = qref.measure %q0
+
+// CHECK-ROUNDTRIP:      %q0 = qubit.alloc
+// CHECK-ROUNDTRIP-NEXT: %q1 = qubit.alloc
+// CHECK-ROUNDTRIP-NEXT: %q0_1 = qssa.gate<#gate.h> %q0
+// CHECK-ROUNDTRIP-NEXT: %q1_1 = qssa.gate<#gate.rz<0.5pi>> %q1
+// CHECK-ROUNDTRIP-NEXT: %q0_2, %q1_2 = qssa.gate<#gate.cnot> %q0_1, %q1_1
+// CHECK-ROUNDTRIP-NEXT: %{{.*}}, %q0_3 = qssa.measure %q0_2
+// CHECK-ROUNDTRIP-NEXT: %g = gate.constant #gate.h
+// CHECK-ROUNDTRIP-NEXT: %q0_4 = qssa.dyn_gate<%g> %q0_3 : !qubit.bit
+// CHECK-ROUNDTRIP-NEXT: %{{.*}}, %q0_5 = qssa.measure %q0_4


### PR DESCRIPTION
Fixes #3 

Have chosen to not implement a full transformation that includes regions and blocks, but instead only convert to qssa if all the uses of the qref qubit are in the same block.