### PR TITLE
transforms: (xz-commute) add pauli propagation

### DIFF
--- a/inconspiquous/transforms/__init__.py
+++ b/inconspiquous/transforms/__init__.py
@@ -66,6 +66,11 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
 
         return randomized_comp.RandomizedComp
 
+    def get_xz_commute():
+        from inconspiquous.transforms.xzs import commute
+
+        return commute.XZCommute
+
     def get_xzs_merge():
         from inconspiquous.transforms.xzs import merge
 
@@ -94,6 +99,7 @@ def get_all_passes() -> dict[str, Callable[[], type[ModulePass]]]:
         "lower-xzs-to-select": get_lower_xzs_to_select,
         "mlir-opt": get_mlir_opt,
         "randomized-comp": get_randomized_comp,
+        "xz-commute": get_xz_commute,
         "xzs-merge": get_xzs_merge,
         "xzs-select": get_xzs_select,
         "xzs-simpl": get_xzs_simpl,

--- a/inconspiquous/transforms/xzs/commute.py
+++ b/inconspiquous/transforms/xzs/commute.py
@@ -1,0 +1,111 @@
+from xdsl.dialects import arith, builtin
+from xdsl.parser import MLContext
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    GreedyRewritePatternApplier,
+    PatternRewriter,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+from inconspiquous.dialects import qssa
+from inconspiquous.dialects.gate import (
+    CNotGate,
+    CZGate,
+    HadamardGate,
+    XZOp,
+)
+from inconspiquous.transforms.xzs.merge import MergeXZGatesPattern
+from inconspiquous.utils.linear_walker import LinearWalker
+
+
+class XZCommutePattern(RewritePattern):
+    """Commute an XZ gadget past a Hadamard/CNot/CZ gate, or MeasureOp."""
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op1: qssa.DynGateOp, rewriter: PatternRewriter):
+        gate = op1.gate.owner
+        if not isinstance(gate, XZOp):
+            return
+        if len(op1.outs[0].uses) != 1:
+            return
+
+        (use,) = op1.outs[0].uses
+
+        op2 = use.operation
+
+        if isinstance(op2, qssa.MeasureOp):
+            new_op2 = qssa.MeasureOp(op1.ins[0])
+            new_op1 = arith.AddiOp(new_op2.out, gate.x)
+
+            rewriter.replace_op(op2, (new_op2, new_op1))
+            rewriter.erase_op(op1)
+
+        if not isinstance(op2, qssa.GateOp):
+            return
+
+        if isinstance(op2.gate, HadamardGate):
+            new_op2 = qssa.GateOp(HadamardGate(), *op1.ins)
+            new_gate = XZOp(gate.z, gate.x)
+            new_op1 = qssa.DynGateOp(new_gate, *new_op2.outs)
+
+            rewriter.replace_op(op2, (new_op2, new_gate, new_op1))
+            rewriter.erase_op(op1)
+
+        if isinstance(op2.gate, CNotGate):
+            c0 = arith.ConstantOp.from_int_and_width(0, 1)
+            if use.index == 0:
+                new_op2 = qssa.GateOp(CNotGate(), *(op1.ins[0], op2.ins[1]))
+                new_op1_left = qssa.DynGateOp(gate, new_op2.outs[0])
+                new_gate_right = XZOp(gate.x, c0)
+                new_op1_right = qssa.DynGateOp(new_gate_right, new_op2.outs[1])
+                rewriter.replace_op(
+                    op2,
+                    (c0, new_op2, new_op1_left, new_gate_right, new_op1_right),
+                    (new_op1_left.outs[0], new_op1_right.outs[0]),
+                )
+                rewriter.erase_op(op1)
+            elif use.index == 1:
+                new_op2 = qssa.GateOp(CNotGate(), *(op2.ins[0], op1.ins[0]))
+                new_gate_left = XZOp(c0, gate.z)
+                new_op1_left = qssa.DynGateOp(new_gate_left, new_op2.outs[0])
+                new_op1_right = qssa.DynGateOp(gate, new_op2.outs[1])
+                rewriter.replace_op(
+                    op2,
+                    (c0, new_op2, new_gate_left, new_op1_left, new_op1_right),
+                    (new_op1_left.outs[0], new_op1_right.outs[0]),
+                )
+                rewriter.erase_op(op1)
+
+        if isinstance(op2.gate, CZGate):
+            c0 = arith.ConstantOp.from_int_and_width(0, 1)
+            if use.index == 0:
+                new_op2 = qssa.GateOp(CZGate(), *(op1.ins[0], op2.ins[1]))
+                new_op1_left = qssa.DynGateOp(gate, new_op2.outs[0])
+                new_gate_right = XZOp(c0, gate.x)
+                new_op1_right = qssa.DynGateOp(new_gate_right, new_op2.outs[1])
+                rewriter.replace_op(
+                    op2,
+                    (c0, new_op2, new_op1_left, new_gate_right, new_op1_right),
+                    (new_op1_left.outs[0], new_op1_right.outs[0]),
+                )
+                rewriter.erase_op(op1)
+            elif use.index == 1:
+                new_op2 = qssa.GateOp(CZGate(), *(op2.ins[0], op1.ins[0]))
+                new_gate_left = XZOp(c0, gate.x)
+                new_op1_left = qssa.DynGateOp(new_gate_left, new_op2.outs[0])
+                new_op1_right = qssa.DynGateOp(gate, new_op2.outs[1])
+                rewriter.replace_op(
+                    op2,
+                    (c0, new_op2, new_gate_left, new_op1_left, new_op1_right),
+                    (new_op1_left.outs[0], new_op1_right.outs[0]),
+                )
+                rewriter.erase_op(op1)
+
+
+class XZCommute(ModulePass):
+    name = "xz-commute"
+
+    def apply(self, ctx: MLContext, op: builtin.ModuleOp) -> None:
+        LinearWalker(
+            GreedyRewritePatternApplier([MergeXZGatesPattern(), XZCommutePattern()])
+        ).rewrite_module(op)

--- a/inconspiquous/utils/linear_walker.py
+++ b/inconspiquous/utils/linear_walker.py
@@ -1,0 +1,82 @@
+from xdsl.ir import Block, Operation, Region
+from xdsl.dialects.builtin import ModuleOp
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    PatternRewriterListener,
+    RewritePattern,
+)
+
+
+class LinearWalker:
+    """
+    For each block in the IR, this runner walks through the operations, continously
+    applying the supplied pattern.
+
+    It functions by maintaining a single pointer to an operation and performs the
+    following:
+    - Run the supplied pattern on the current operation
+    - If the pattern does no action, then move the pointer forward one
+    - If the pattern deletes the current operation, then backtrack by one operation
+    We repeat this until we reach the end of the block.
+    """
+
+    pattern: RewritePattern
+    """
+    The pattern to be run.
+    """
+
+    _current_operation: Operation | None
+    """
+    Pointer to the current operation
+    """
+
+    _listener: PatternRewriterListener
+
+    def __init__(self, pattern: RewritePattern) -> None:
+        self.pattern = pattern
+        self._current_operation = None
+        self._listener = PatternRewriterListener(
+            operation_removal_handler=[
+                self._handle_operation_removal,
+            ]
+        )
+
+    def _handle_operation_removal(self, op: Operation):
+        if op == self._current_operation:
+            assert self._current_operation is not None
+            if (prev := self._current_operation.prev_op) is None:
+                block = self._current_operation.parent_block()
+                assert block is not None
+                self._current_operation = block.first_op
+            else:
+                self._current_operation = prev
+
+    def rewrite_module(self, module: ModuleOp) -> bool:
+        return self.rewrite_region(module.body)
+
+    def rewrite_region(self, region: Region) -> bool:
+        modified = False
+        for block in region.blocks:
+            modified |= self.rewrite_block(block)
+
+        return modified
+
+    def rewrite_block(self, block: Block) -> bool:
+        modified = False
+        for op in block.ops:
+            for region in op.regions:
+                modified |= self.rewrite_region(region)
+
+        self._current_operation = block.first_op
+
+        while self._current_operation is not None:
+            rewriter = PatternRewriter(self._current_operation)
+            rewriter.extend_from_listener(self._listener)
+            self.pattern.match_and_rewrite(self._current_operation, rewriter)
+
+            if rewriter.has_done_action:
+                modified = True
+            else:
+                self._current_operation = self._current_operation.next_op
+
+        return modified

--- a/tests/filecheck/transforms/xzs/commute.mlir
+++ b/tests/filecheck/transforms/xzs/commute.mlir
@@ -1,0 +1,73 @@
+// RUN: quopt %s -p xz-commute,dce | filecheck %s
+
+// CHECK:      func.func @h_commute(%q : !qubit.bit, %x : i1, %z : i1) {
+// CHECK-NEXT:   %q_1 = qssa.gate<#gate.h> %q
+// CHECK-NEXT:   %q_2 = gate.xz %z, %x
+// CHECK-NEXT:   %q_3 = qssa.dyn_gate<%q_2> %q_1 : !qubit.bit
+// CHECK-NEXT:   func.return
+// CHECK-NEXT: }
+
+func.func @h_commute(%q : !qubit.bit, %x : i1, %z : i1) {
+  %g = gate.xz %x, %z
+  %q_1 = qssa.dyn_gate<%g> %q : !qubit.bit
+  %q_2 = qssa.gate<#gate.h> %q_1
+  func.return
+}
+
+// CHECK:      func.func @cz_commute(%q1 : !qubit.bit, %q2 : !qubit.bit, %x1 : i1, %z1 : i1, %x2 : i1, %z2 : i1) {
+// CHECK-NEXT:   %0 = arith.addi %1, %x1 : i1
+// CHECK-NEXT:   %2 = arith.addi %x2, %z1 : i1
+// CHECK-NEXT:   %3 = gate.xz %0, %2
+// CHECK-NEXT:   %4 = arith.constant false
+// CHECK-NEXT:   %1 = arith.constant false
+// CHECK-NEXT:   %5, %6 = qssa.gate<#gate.cz> %q1, %q2
+// CHECK-NEXT:   %q1_1 = qssa.dyn_gate<%3> %5 : !qubit.bit
+// CHECK-NEXT:   %7 = arith.addi %x2, %4 : i1
+// CHECK-NEXT:   %8 = arith.addi %z2, %x1 : i1
+// CHECK-NEXT:   %g2 = gate.xz %7, %8
+// CHECK-NEXT:   %q2_1 = qssa.dyn_gate<%g2> %6 : !qubit.bit
+// CHECK-NEXT:   func.return
+// CHECK-NEXT: }
+func.func @cz_commute(%q1 : !qubit.bit, %q2 : !qubit.bit, %x1 : i1, %z1 : i1, %x2 : i1, %z2 : i1) {
+  %g1 = gate.xz %x1, %z1
+  %g2 = gate.xz %x2, %z2
+  %q1_1 = qssa.dyn_gate<%g1> %q1 : !qubit.bit
+  %q2_1 = qssa.dyn_gate<%g2> %q2 : !qubit.bit
+  %q1_2, %q2_2 = qssa.gate<#gate.cz> %q1_1, %q2_1
+  func.return
+}
+
+// CHECK:      func.func @cnot_commute(%q1 : !qubit.bit, %q2 : !qubit.bit, %x1 : i1, %z1 : i1, %x2 : i1, %z2 : i1) {
+// CHECK-NEXT:   %0 = arith.addi %1, %x1 : i1
+// CHECK-NEXT:   %2 = arith.addi %z2, %z1 : i1
+// CHECK-NEXT:   %3 = gate.xz %0, %2
+// CHECK-NEXT:   %4 = arith.constant false
+// CHECK-NEXT:   %1 = arith.constant false
+// CHECK-NEXT:   %5, %6 = qssa.gate<#gate.cnot> %q1, %q2
+// CHECK-NEXT:   %q1_1 = qssa.dyn_gate<%3> %5 : !qubit.bit
+// CHECK-NEXT:   %7 = arith.addi %x2, %x1 : i1
+// CHECK-NEXT:   %8 = arith.addi %z2, %4 : i1
+// CHECK-NEXT:   %g2 = gate.xz %7, %8
+// CHECK-NEXT:   %q2_1 = qssa.dyn_gate<%g2> %6 : !qubit.bit
+// CHECK-NEXT:   func.return
+// CHECK-NEXT: }
+func.func @cnot_commute(%q1 : !qubit.bit, %q2 : !qubit.bit, %x1 : i1, %z1 : i1, %x2 : i1, %z2 : i1) {
+  %g1 = gate.xz %x1, %z1
+  %g2 = gate.xz %x2, %z2
+  %q1_1 = qssa.dyn_gate<%g1> %q1 : !qubit.bit
+  %q2_1 = qssa.dyn_gate<%g2> %q2 : !qubit.bit
+  %q1_2, %q2_2 = qssa.gate<#gate.cnot> %q1_1, %q2_1
+  func.return
+}
+
+// CHECK:      func.func @measure_commute(%q : !qubit.bit, %x : i1, %z : i1) -> i1 {
+// CHECK-NEXT:   %0 = qssa.measure %q
+// CHECK-NEXT:   %1 = arith.addi %0, %x : i1
+// CHECK-NEXT:   func.return %1 : i1
+// CHECK-NEXT: }
+func.func @measure_commute(%q : !qubit.bit, %x : i1, %z : i1) -> i1 {
+  %g = gate.xz %x, %z
+  %q_1 = qssa.dyn_gate<%g> %q : !qubit.bit
+  %0 = qssa.measure %q_1
+  func.return %0 : i1
+}

--- a/tests/filecheck/transforms/xzs/commute.mlir
+++ b/tests/filecheck/transforms/xzs/commute.mlir
@@ -15,17 +15,17 @@ func.func @h_commute(%q : !qubit.bit, %x : i1, %z : i1) {
 }
 
 // CHECK:      func.func @cz_commute(%q1 : !qubit.bit, %q2 : !qubit.bit, %x1 : i1, %z1 : i1, %x2 : i1, %z2 : i1) {
-// CHECK-NEXT:   %0 = arith.addi %1, %x1 : i1
-// CHECK-NEXT:   %2 = arith.addi %x2, %z1 : i1
-// CHECK-NEXT:   %3 = gate.xz %0, %2
-// CHECK-NEXT:   %4 = arith.constant false
+// CHECK-NEXT:   %0 = arith.constant false
 // CHECK-NEXT:   %1 = arith.constant false
-// CHECK-NEXT:   %5, %6 = qssa.gate<#gate.cz> %q1, %q2
-// CHECK-NEXT:   %q1_1 = qssa.dyn_gate<%3> %5 : !qubit.bit
-// CHECK-NEXT:   %7 = arith.addi %x2, %4 : i1
-// CHECK-NEXT:   %8 = arith.addi %z2, %x1 : i1
+// CHECK-NEXT:   %2, %3 = qssa.gate<#gate.cz> %q1, %q2
+// CHECK-NEXT:   %4 = arith.xori %1, %x1 : i1
+// CHECK-NEXT:   %5 = arith.xori %x2, %z1 : i1
+// CHECK-NEXT:   %6 = gate.xz %4, %5
+// CHECK-NEXT:   %q1_1 = qssa.dyn_gate<%6> %2 : !qubit.bit
+// CHECK-NEXT:   %7 = arith.xori %x2, %0 : i1
+// CHECK-NEXT:   %8 = arith.xori %z2, %x1 : i1
 // CHECK-NEXT:   %g2 = gate.xz %7, %8
-// CHECK-NEXT:   %q2_1 = qssa.dyn_gate<%g2> %6 : !qubit.bit
+// CHECK-NEXT:   %q2_1 = qssa.dyn_gate<%g2> %3 : !qubit.bit
 // CHECK-NEXT:   func.return
 // CHECK-NEXT: }
 func.func @cz_commute(%q1 : !qubit.bit, %q2 : !qubit.bit, %x1 : i1, %z1 : i1, %x2 : i1, %z2 : i1) {
@@ -38,17 +38,17 @@ func.func @cz_commute(%q1 : !qubit.bit, %q2 : !qubit.bit, %x1 : i1, %z1 : i1, %x
 }
 
 // CHECK:      func.func @cnot_commute(%q1 : !qubit.bit, %q2 : !qubit.bit, %x1 : i1, %z1 : i1, %x2 : i1, %z2 : i1) {
-// CHECK-NEXT:   %0 = arith.addi %1, %x1 : i1
-// CHECK-NEXT:   %2 = arith.addi %z2, %z1 : i1
-// CHECK-NEXT:   %3 = gate.xz %0, %2
-// CHECK-NEXT:   %4 = arith.constant false
+// CHECK-NEXT:   %0 = arith.constant false
 // CHECK-NEXT:   %1 = arith.constant false
-// CHECK-NEXT:   %5, %6 = qssa.gate<#gate.cnot> %q1, %q2
-// CHECK-NEXT:   %q1_1 = qssa.dyn_gate<%3> %5 : !qubit.bit
-// CHECK-NEXT:   %7 = arith.addi %x2, %x1 : i1
-// CHECK-NEXT:   %8 = arith.addi %z2, %4 : i1
+// CHECK-NEXT:   %2, %3 = qssa.gate<#gate.cnot> %q1, %q2
+// CHECK-NEXT:   %4 = arith.xori %1, %x1 : i1
+// CHECK-NEXT:   %5 = arith.xori %z2, %z1 : i1
+// CHECK-NEXT:   %6 = gate.xz %4, %5
+// CHECK-NEXT:   %q1_1 = qssa.dyn_gate<%6> %2 : !qubit.bit
+// CHECK-NEXT:   %7 = arith.xori %x2, %x1 : i1
+// CHECK-NEXT:   %8 = arith.xori %z2, %0 : i1
 // CHECK-NEXT:   %g2 = gate.xz %7, %8
-// CHECK-NEXT:   %q2_1 = qssa.dyn_gate<%g2> %6 : !qubit.bit
+// CHECK-NEXT:   %q2_1 = qssa.dyn_gate<%g2> %3 : !qubit.bit
 // CHECK-NEXT:   func.return
 // CHECK-NEXT: }
 func.func @cnot_commute(%q1 : !qubit.bit, %q2 : !qubit.bit, %x1 : i1, %z1 : i1, %x2 : i1, %z2 : i1) {


### PR DESCRIPTION
Adds pauli propagation through the `xz` gadget. Includes a purpose built runner for pattern rewrites which avoids exponential runtime of this procedure.

I've hard coded measurement, cnot, cz, and hadamard here. In the future we may want to find a way to encode the propagation information as part of the gate class.