### PR TITLE
dialects: (qssa/qref/measurement) add dynamic measurement

### DIFF
--- a/inconspiquous/dialects/gate.py
+++ b/inconspiquous/dialects/gate.py
@@ -106,6 +106,43 @@ class AngleAttr(ParametrizedAttribute):
 
 
 @irdl_attr_definition
+class AngleType(ParametrizedAttribute, TypeAttribute):
+    """
+    A type for runtime angle values.
+    """
+
+    name = "gate.angle_type"
+
+
+@irdl_op_definition
+class ConstantAngleOp(IRDLOperation):
+    """
+    Constant-like operation for producing angles
+    """
+
+    name = "gate.constant_angle"
+
+    angle = prop_def(AngleAttr)
+
+    out = result_def(AngleType)
+
+    assembly_format = "`` $angle attr-dict"
+
+    traits = traits_def(
+        ConstantLike(),
+        Pure(),
+    )
+
+    def __init__(self, angle: AngleAttr):
+        super().__init__(
+            properties={
+                "angle": angle,
+            },
+            result_types=(AngleType(),),
+        )
+
+
+@irdl_attr_definition
 class HadamardGate(SingleQubitGate):
     name = "gate.h"
 
@@ -398,9 +435,10 @@ class XZOp(IRDLOperation):
 
 Gate = Dialect(
     "gate",
-    [ConstantGateOp, QuaternionGateOp, ComposeGateOp, XZSOp, XZOp],
+    [ConstantAngleOp, ConstantGateOp, QuaternionGateOp, ComposeGateOp, XZSOp, XZOp],
     [
         AngleAttr,
+        AngleType,
         HadamardGate,
         XGate,
         YGate,

--- a/inconspiquous/dialects/measurement.py
+++ b/inconspiquous/dialects/measurement.py
@@ -1,14 +1,32 @@
 from __future__ import annotations
+from typing import ClassVar
 
-from xdsl.ir import Dialect
+from xdsl.ir import Dialect, Operation, ParametrizedAttribute, SSAValue, TypeAttribute
 from xdsl.irdl import (
+    AnyInt,
+    GenericAttrConstraint,
+    IRDLOperation,
+    IntConstraint,
+    IntVarConstraint,
+    ParamAttrConstraint,
     ParameterDef,
     irdl_attr_definition,
+    eq,
+    irdl_op_definition,
+    operand_def,
+    prop_def,
+    result_def,
+    traits_def,
 )
 from xdsl.parser import AttrParser
+from xdsl.pattern_rewriter import RewritePattern
 from xdsl.printer import Printer
 from inconspiquous.dialects.gate import AngleAttr
 from inconspiquous.measurement import MeasurementAttr
+from xdsl.dialects.builtin import IndexType, IntAttrConstraint, IntegerAttr
+from xdsl.traits import ConstantLike, HasCanonicalizationPatternsTrait, Pure
+from inconspiquous.constraints import SizedAttributeConstraint
+from inconspiquous.dialects.gate import AngleType
 
 
 @irdl_attr_definition
@@ -52,11 +70,110 @@ class XYMeasurementAttr(MeasurementAttr):
         return 1
 
 
+@irdl_attr_definition
+class MeasurementType(ParametrizedAttribute, TypeAttribute):
+    """
+    A type for dynamic measurements.
+    """
+
+    name = "measurement.type"
+
+    num_qubits: ParameterDef[IntegerAttr[IndexType]]
+
+    def __init__(self, num_qubits: int | IntegerAttr[IndexType]):
+        if isinstance(num_qubits, int):
+            num_qubits = IntegerAttr.from_index_int_value(num_qubits)
+        super().__init__((num_qubits,))
+
+    @classmethod
+    def parse_parameters(cls, parser: AttrParser) -> tuple[IntegerAttr[IndexType]]:
+        with parser.in_angle_brackets():
+            i = parser.parse_integer(allow_boolean=False, allow_negative=False)
+            return (IntegerAttr.from_index_int_value(i),)
+
+    def print_parameters(self, printer: Printer) -> None:
+        with printer.in_angle_brackets():
+            printer.print_string(str(self.num_qubits.value.data))
+
+    @staticmethod
+    def constr(int_constraint: IntConstraint) -> GenericAttrConstraint[MeasurementType]:
+        return ParamAttrConstraint(
+            MeasurementType,
+            (
+                IntegerAttr.constr(
+                    value=IntAttrConstraint(int_constraint), type=eq(IndexType())
+                ),
+            ),
+        )
+
+
+@irdl_op_definition
+class ConstantMeasurmentOp(IRDLOperation):
+    """
+    Constant-like operation for producing measurement types from measurement attributes.
+    """
+
+    _I: ClassVar = IntVarConstraint("I", AnyInt())
+
+    name = "measurement.constant"
+
+    measurement = prop_def(SizedAttributeConstraint(MeasurementAttr, _I))
+
+    out = result_def(MeasurementType.constr(_I))
+
+    assembly_format = "$measurement attr-dict"
+
+    traits = traits_def(
+        ConstantLike(),
+        Pure(),
+    )
+
+    def __init__(self, measurement: MeasurementAttr):
+        super().__init__(
+            properties={
+                "measurement": measurement,
+            },
+            result_types=(MeasurementType(measurement.num_qubits),),
+        )
+
+
+class XYDynMeasurementOpHasCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
+    @classmethod
+    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+        from inconspiquous.transforms.canonicalization import measurement
+
+        return (measurement.XYDynMeasurementConst(),)
+
+
+@irdl_op_definition
+class XYDynMeasurementOp(IRDLOperation):
+    """
+    Generate a measurement type for a measurement on the XY plane with input angle.
+    """
+
+    name = "measurement.dyn_xy"
+
+    angle = operand_def(AngleType)
+
+    out = result_def(MeasurementType(1))
+
+    assembly_format = "`<` $angle `>` attr-dict"
+
+    traits = traits_def(Pure(), XYDynMeasurementOpHasCanonicalizationPatterns())
+
+    def __init__(self, angle: SSAValue | Operation):
+        super().__init__(operands=(angle,), result_types=(MeasurementType(1),))
+
+
 Measurement = Dialect(
     "measurement",
-    [],
+    [
+        ConstantMeasurmentOp,
+        XYDynMeasurementOp,
+    ],
     [
         CompBasisMeasurementAttr,
         XYMeasurementAttr,
+        MeasurementType,
     ],
 )

--- a/inconspiquous/dialects/qref.py
+++ b/inconspiquous/dialects/qref.py
@@ -18,7 +18,7 @@ from xdsl.pattern_rewriter import RewritePattern
 from xdsl.traits import HasCanonicalizationPatternsTrait
 
 from inconspiquous.dialects.gate import GateType
-from inconspiquous.dialects.measurement import CompBasisMeasurementAttr
+from inconspiquous.dialects.measurement import CompBasisMeasurementAttr, MeasurementType
 from inconspiquous.gates import GateAttr
 from inconspiquous.dialects.qubit import BitType
 from inconspiquous.constraints import SizedAttributeConstraint
@@ -105,12 +105,48 @@ class MeasureOp(IRDLOperation):
         )
 
 
+class DynMeasureOpHasCanonicalizationPatterns(HasCanonicalizationPatternsTrait):
+    @classmethod
+    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+        from inconspiquous.transforms.canonicalization.qref import (
+            DynMeasureConst,
+        )
+
+        return (DynMeasureConst(),)
+
+
+@irdl_op_definition
+class DynMeasureOp(IRDLOperation):
+    name = "qref.dyn_measure"
+
+    _I: ClassVar = IntVarConstraint("I", AnyInt())
+
+    measurement = operand_def(MeasurementType.constr(_I))
+
+    in_qubits = var_operand_def(RangeOf(eq(BitType()), length=_I))
+
+    outs = var_result_def(RangeOf(eq(i1), length=_I))
+
+    assembly_format = "`<` $measurement `>` $in_qubits attr-dict"
+
+    traits = traits_def(DynMeasureOpHasCanonicalizationPatterns())
+
+    def __init__(
+        self, measurement: SSAValue | Operation, *in_qubits: SSAValue | Operation
+    ):
+        super().__init__(
+            operands=[measurement, in_qubits],
+            result_types=(tuple(i1 for _ in in_qubits),),
+        )
+
+
 Qref = Dialect(
     "qref",
     [
         GateOp,
         DynGateOp,
         MeasureOp,
+        DynMeasureOp,
     ],
     [],
 )

--- a/inconspiquous/transforms/canonicalization/measurement.py
+++ b/inconspiquous/transforms/canonicalization/measurement.py
@@ -1,0 +1,27 @@
+from xdsl.pattern_rewriter import (
+    PatternRewriter,
+    RewritePattern,
+    op_type_rewrite_pattern,
+)
+
+from inconspiquous.dialects.gate import ConstantAngleOp
+from inconspiquous.dialects.measurement import (
+    ConstantMeasurmentOp,
+    XYDynMeasurementOp,
+    XYMeasurementAttr,
+)
+
+
+class XYDynMeasurementConst(RewritePattern):
+    """
+    Replaces a dynamic xy measurement with constant angle with a constant xy measurement.
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: XYDynMeasurementOp, rewriter: PatternRewriter):
+        if not isinstance(owner := op.angle.owner, ConstantAngleOp):
+            return
+
+        rewriter.replace_matched_op(
+            ConstantMeasurmentOp(XYMeasurementAttr(owner.angle))
+        )

--- a/inconspiquous/transforms/canonicalization/qref.py
+++ b/inconspiquous/transforms/canonicalization/qref.py
@@ -5,8 +5,8 @@ from xdsl.pattern_rewriter import (
 )
 
 from inconspiquous.dialects.gate import ConstantGateOp
-from inconspiquous.dialects.qref import GateOp
-from inconspiquous.dialects.qref import DynGateOp
+from inconspiquous.dialects.measurement import ConstantMeasurmentOp
+from inconspiquous.dialects.qref import DynMeasureOp, GateOp, DynGateOp, MeasureOp
 
 
 class DynGateConst(RewritePattern):
@@ -19,3 +19,16 @@ class DynGateConst(RewritePattern):
         owner = op.gate.owner
         if isinstance(owner, ConstantGateOp):
             rewriter.replace_matched_op(GateOp(owner.gate, *op.ins))
+
+
+class DynMeasureConst(RewritePattern):
+    """
+    Simplifies a dynamic measurement with constant measurement to a regular measurement
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: DynMeasureOp, rewriter: PatternRewriter):
+        if isinstance(owner := op.measurement.owner, ConstantMeasurmentOp):
+            rewriter.replace_matched_op(
+                MeasureOp(*op.in_qubits, measurement=owner.measurement)
+            )

--- a/inconspiquous/transforms/canonicalization/qssa.py
+++ b/inconspiquous/transforms/canonicalization/qssa.py
@@ -5,8 +5,8 @@ from xdsl.pattern_rewriter import (
 )
 
 from inconspiquous.dialects.gate import ComposeGateOp, ConstantGateOp, IdentityGate
-from inconspiquous.dialects.qssa import GateOp
-from inconspiquous.dialects.qssa import DynGateOp
+from inconspiquous.dialects.measurement import ConstantMeasurmentOp
+from inconspiquous.dialects.qssa import DynMeasureOp, GateOp, MeasureOp, DynGateOp
 
 
 class DynGateConst(RewritePattern):
@@ -42,3 +42,16 @@ class GateIdentity(RewritePattern):
     def match_and_rewrite(self, op: GateOp, rewriter: PatternRewriter):
         if isinstance(op.gate, IdentityGate):
             rewriter.replace_matched_op((), op.ins)
+
+
+class DynMeasureConst(RewritePattern):
+    """
+    Simplifies a dynamic measurement with constant measurement to a regular measurement
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: DynMeasureOp, rewriter: PatternRewriter):
+        if isinstance(owner := op.measurement.owner, ConstantMeasurmentOp):
+            rewriter.replace_matched_op(
+                MeasureOp(*op.in_qubits, measurement=owner.measurement)
+            )

--- a/tests/filecheck/dialects/gate.mlir
+++ b/tests/filecheck/dialects/gate.mlir
@@ -51,6 +51,10 @@
 // CHECK-NEXT: %{{.*}} = gate.constant #gate.cz
 // CHECK-GENERIC-NEXT: %{{.*}} = "gate.constant"() <{gate = #gate.cz}> : () -> !gate.type<2>
 
+// CHECK-NEXT: %{{.*}} = gate.constant_angle<pi>
+// CHECK-GENERIC-NEXT: %{{.*}} = "gate.constant_angle"() <{angle = #gate.angle<pi>}> : () -> !gate.angle_type
+%a = gate.constant_angle<pi>
+
 %zero = arith.constant 0 : i64
 %one = arith.constant 1 : i64
 

--- a/tests/filecheck/dialects/measurement/canonicalize.mlir
+++ b/tests/filecheck/dialects/measurement/canonicalize.mlir
@@ -1,0 +1,12 @@
+// RUN: quopt -p canonicalize %s | filecheck %s
+
+%a = gate.constant_angle<0>
+
+%m = measurement.dyn_xy<%a>
+
+"test.op"(%m) : (!measurement.type<1>) -> ()
+
+// CHECK:       builtin.module {
+// CHECK-NEXT:    %m = measurement.constant #measurement.xy<0>
+// CHECK-NEXT:    "test.op"(%m) : (!measurement.type<1>) -> ()
+// CHECK-NEXT:  }

--- a/tests/filecheck/dialects/measurement/ops.mlir
+++ b/tests/filecheck/dialects/measurement/ops.mlir
@@ -1,0 +1,18 @@
+// RUN: QUOPT_ROUNDTRIP
+// RUN: QUOPT_GENERIC_ROUNDTRIP
+
+// CHECK: "test.op"() {measurement = #measurement.comp_basis} : () -> ()
+"test.op"() {measurement = #measurement.comp_basis} : () -> ()
+
+// CHECK: "test.op"() {measurement = #measurement.xy<pi>} : () -> ()
+"test.op"() {measurement = #measurement.xy<pi>} : () -> ()
+
+// CHECK: %m = measurement.constant #measurement.comp_basis
+// CHECK-GENERIC: %m = "measurement.constant"() <{measurement = #measurement.comp_basis}> : () -> !measurement.type<1>
+%m = measurement.constant #measurement.comp_basis
+
+%a = "test.op"() : () -> !gate.angle_type
+
+// CHECK: %m2 = measurement.dyn_xy<%a>
+// CHECK-GENERIC: %m2 = "measurement.dyn_xy"(%a) : (!gate.angle_type) -> !measurement.type<1>
+%m2 = measurement.dyn_xy<%a>

--- a/tests/filecheck/dialects/qref/canonicalize.mlir
+++ b/tests/filecheck/dialects/qref/canonicalize.mlir
@@ -1,12 +1,16 @@
 // RUN: quopt -p canonicalize %s | filecheck %s
 
 %g = "gate.constant"() <{"gate" = #gate.h}> : () -> !gate.type<1>
+%m = "measurement.constant"() <{"measurement" = #measurement.comp_basis}> : () -> !measurement.type<1>
 
 %q1 = qubit.alloc
 
 "qref.dyn_gate"(%g, %q1) : (!gate.type<1>, !qubit.bit) -> ()
 
+%0 = "qref.dyn_measure"(%m, %q1) : (!measurement.type<1>, !qubit.bit) -> i1
+
 // CHECK:       builtin.module {
 // CHECK-NEXT:    %q1 = qubit.alloc
 // CHECK-NEXT:    qref.gate<#gate.h> %q1
+// CHECK-NEXT:    %{{.*}} = qref.measure %q1
 // CHECK-NEXT:  }

--- a/tests/filecheck/dialects/qref/ops.mlir
+++ b/tests/filecheck/dialects/qref/ops.mlir
@@ -30,3 +30,15 @@ qref.dyn_gate<%g1> %q1
 // CHECK: %{{.*}} = qref.measure %q0
 // CHECK-GENERIC: %{{.*}} = "qref.measure"(%q0) <{measurement = #measurement.comp_basis}> : (!qubit.bit) -> i1
 %0 = qref.measure %q0
+
+// CHECK: %{{.*}} = qref.measure<#measurement.xy<0.5pi>> %q1
+// CHECK-GENERIC: %{{.*}} = "qref.measure"(%q1) <{measurement = #measurement.xy<0.5pi>}> : (!qubit.bit) -> i1
+%1 = qref.measure<#measurement.xy<0.5pi>> %q1
+
+%q2 = qubit.alloc
+
+%m = "test.op"() : () -> !measurement.type<1>
+
+// CHECK: %{{.*}} = qref.dyn_measure<%m> %q2
+// CHECK-GENERIC: %{{.*}} = "qref.dyn_measure"(%m, %q2) : (!measurement.type<1>, !qubit.bit) -> i1
+%2 = qref.dyn_measure<%m> %q2

--- a/tests/filecheck/dialects/qssa/canonicalize.mlir
+++ b/tests/filecheck/dialects/qssa/canonicalize.mlir
@@ -1,12 +1,16 @@
 // RUN: quopt -p canonicalize %s | filecheck %s
 
 %g = "gate.constant"() <{"gate" = #gate.h}> : () -> !gate.type<1>
+%m = "measurement.constant"() <{"measurement" = #measurement.comp_basis}> : () -> !measurement.type<1>
 
 %q1 = qubit.alloc
 
 %q2 = "qssa.dyn_gate"(%g, %q1) : (!gate.type<1>, !qubit.bit) -> !qubit.bit
 
+%0 = "qssa.dyn_measure"(%m, %q2) : (!measurement.type<1>, !qubit.bit) -> i1
+
 // CHECK:       builtin.module {
 // CHECK-NEXT:    %q1 = qubit.alloc
 // CHECK-NEXT:    %q2 = qssa.gate<#gate.h> %q1
+// CHECK-NEXT:    %{{.*}} = qssa.measure %q2
 // CHECK-NEXT:  }

--- a/tests/filecheck/dialects/qssa/ops.mlir
+++ b/tests/filecheck/dialects/qssa/ops.mlir
@@ -34,3 +34,11 @@
 // CHECK: %{{.*}} = qssa.measure<#measurement.xy<0.5pi>> %q6
 // CHECK-GENERIC: %{{.*}} = "qssa.measure"(%q6) <{measurement = #measurement.xy<0.5pi>}> : (!qubit.bit) -> i1
 %1 = qssa.measure<#measurement.xy<0.5pi>> %q6
+
+%q7 = qubit.alloc
+
+%m = "test.op"() : () -> !measurement.type<1>
+
+// CHECK: %{{.*}} = qssa.dyn_measure<%m> %q7
+// CHECK-GENERIC: %{{.*}} = "qssa.dyn_measure"(%m, %q7) : (!measurement.type<1>, !qubit.bit) -> i1
+%2 = qssa.dyn_measure<%m> %q7


### PR DESCRIPTION
Adds dynamic measurement to qssa/qref, an angle type, and a dynamic xy plane measurement. Everything should be covered by a filecheck test (unless I've missed something).

I want to follow this with a large restructuring of dialects, as I don't think angle should belong in gate any more.

Stacked PR