### PR TITLE
dialects: (angle) add extra cond_negate canonicalization

### DIFF
--- a/inconspiquous/dialects/angle.py
+++ b/inconspiquous/dialects/angle.py
@@ -121,6 +121,7 @@ class CondNegateAngleOpHasCanonicalizationPatterns(HasCanonicalizationPatternsTr
         from inconspiquous.transforms.canonicalization import angle
 
         return (
+            angle.CondNegateAngleOpZeroPiPattern(),
             angle.CondNegateAngleOpFoldPattern(),
             angle.CondNegateAngleOpAssocPattern(),
         )

--- a/inconspiquous/transforms/canonicalization/angle.py
+++ b/inconspiquous/transforms/canonicalization/angle.py
@@ -11,7 +11,7 @@ from inconspiquous.dialects.angle import CondNegateAngleOp, ConstantAngleOp
 
 class CondNegateAngleOpZeroPiPattern(RewritePattern):
     """
-    Negating a zero angle on pi angle has no effect.
+    Negating a zero angle or pi angle has no effect.
     """
 
     @op_type_rewrite_pattern

--- a/inconspiquous/transforms/canonicalization/angle.py
+++ b/inconspiquous/transforms/canonicalization/angle.py
@@ -9,6 +9,20 @@ from xdsl.transforms.canonicalization_patterns.utils import const_evaluate_opera
 from inconspiquous.dialects.angle import CondNegateAngleOp, ConstantAngleOp
 
 
+class CondNegateAngleOpZeroPiPattern(RewritePattern):
+    """
+    Negating a zero angle on pi angle has no effect.
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: CondNegateAngleOp, rewriter: PatternRewriter):
+        if (
+            isinstance(op.angle.owner, ConstantAngleOp)
+            and op.angle.owner.angle == -op.angle.owner.angle
+        ):
+            rewriter.replace_matched_op((), (op.angle,))
+
+
 class CondNegateAngleOpFoldPattern(RewritePattern):
     """
     Fold an angle.cond_negate when both arguments are constant.

--- a/tests/filecheck/dialects/angle/canonicalize.mlir
+++ b/tests/filecheck/dialects/angle/canonicalize.mlir
@@ -26,3 +26,12 @@
 // CHECK: [[assoc:%.*]] = angle.cond_negate [[xor]], %a
 // CHECK: "test.op"([[assoc]]) : (!angle.type) -> ()
 "test.op"(%f) : (!angle.type) -> ()
+
+%g = angle.constant<pi>
+%h = angle.cond_negate %x, %g
+
+%i = angle.constant<0>
+%j = angle.cond_negate %y, %i
+
+// CHECK: "test.op"(%g, %i) {pi_or_zero} : (!angle.type, !angle.type) -> ()
+"test.op"(%h, %j) {pi_or_zero} : (!angle.type, !angle.type) -> ()


### PR DESCRIPTION
Negating a zero or pi angle doesn't do anything.