### PR TITLE
transforms: (convert-qref/qssa) include dynamic measurement

### DIFF
--- a/inconspiquous/dialects/qref.py
+++ b/inconspiquous/dialects/qref.py
@@ -87,7 +87,7 @@ class MeasureOp(IRDLOperation):
 
     in_qubits = var_operand_def(RangeOf(eq(BitType()), length=_I))
 
-    out = var_result_def(RangeOf(eq(i1), length=_I))
+    outs = var_result_def(RangeOf(eq(i1), length=_I))
 
     assembly_format = "(`` `<` $measurement^ `>`)? $in_qubits attr-dict"
 
@@ -132,7 +132,7 @@ class DynMeasureOp(IRDLOperation):
     traits = traits_def(DynMeasureOpHasCanonicalizationPatterns())
 
     def __init__(
-        self, measurement: SSAValue | Operation, *in_qubits: SSAValue | Operation
+        self, *in_qubits: SSAValue | Operation, measurement: SSAValue | Operation
     ):
         super().__init__(
             operands=[measurement, in_qubits],

--- a/inconspiquous/dialects/qssa.py
+++ b/inconspiquous/dialects/qssa.py
@@ -106,7 +106,7 @@ class MeasureOp(IRDLOperation):
 
     in_qubits = var_operand_def(RangeOf(eq(BitType()), length=_I))
 
-    out = var_result_def(RangeOf(eq(i1), length=_I))
+    outs = var_result_def(RangeOf(eq(i1), length=_I))
 
     assembly_format = "(`` `<` $measurement^ `>`)? $in_qubits attr-dict"
 
@@ -151,7 +151,9 @@ class DynMeasureOp(IRDLOperation):
     traits = traits_def(DynMeasureOpHasCanonicalizationPatterns())
 
     def __init__(
-        self, measurement: SSAValue | Operation, *in_qubits: SSAValue | Operation
+        self,
+        *in_qubits: SSAValue | Operation,
+        measurement: SSAValue | Operation,
     ):
         super().__init__(
             operands=[measurement, in_qubits],

--- a/inconspiquous/transforms/convert_qref_to_qssa.py
+++ b/inconspiquous/transforms/convert_qref_to_qssa.py
@@ -46,7 +46,9 @@ class ConvertQrefMeasureToQssaMeasure(RewritePattern):
     """
 
     @op_type_rewrite_pattern
-    def match_and_rewrite(self, op: qref.MeasureOp, rewriter: PatternRewriter):
+    def match_and_rewrite(
+        self, op: qref.MeasureOp | qref.DynMeasureOp, rewriter: PatternRewriter
+    ):
         # Don't rewrite if uses live in different blocks
         if op.parent_block() is None:
             return
@@ -59,9 +61,12 @@ class ConvertQrefMeasureToQssaMeasure(RewritePattern):
                 if len(operand.uses) != 1:
                     return
 
-        new_op = qssa.MeasureOp(*op.in_qubits, measurement=op.measurement)
+        if isinstance(op, qref.MeasureOp):
+            new_op = qssa.MeasureOp(*op.in_qubits, measurement=op.measurement)
+        else:
+            new_op = qssa.DynMeasureOp(*op.in_qubits, measurement=op.measurement)
 
-        rewriter.replace_matched_op(new_op, new_op.out)
+        rewriter.replace_matched_op(new_op, new_op.outs)
 
 
 class ConvertQrefToQssa(ModulePass):

--- a/inconspiquous/transforms/convert_qssa_to_qref.py
+++ b/inconspiquous/transforms/convert_qssa_to_qref.py
@@ -19,7 +19,7 @@ class ConvertQssaGateToQrefGate(RewritePattern):
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: qssa.GateOp, rewriter: PatternRewriter):
-        rewriter.replace_matched_op(qref.GateOp(op.gate, *op.ins), op.operands)
+        rewriter.replace_matched_op(qref.GateOp(op.gate, *op.ins), op.ins)
 
 
 class ConvertQssaDynGateToQrefDynGate(RewritePattern):
@@ -43,6 +43,17 @@ class ConvertQssaMeasureToQrefMeasure(RewritePattern):
         rewriter.replace_matched_op(new_measure)
 
 
+class ConvertQssaDynMeasureToQrefDynMeasure(RewritePattern):
+    """
+    Replaces a qssa measurement by its qref counterpart.
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: qssa.DynMeasureOp, rewriter: PatternRewriter):
+        new_measure = qref.DynMeasureOp(*op.in_qubits, measurement=op.measurement)
+        rewriter.replace_matched_op(new_measure)
+
+
 class ConvertQssaToQref(ModulePass):
     """
     Converts uses of the qssa dialect to the qref dialect in a module.
@@ -58,6 +69,7 @@ class ConvertQssaToQref(ModulePass):
                     ConvertQssaGateToQrefGate(),
                     ConvertQssaDynGateToQrefDynGate(),
                     ConvertQssaMeasureToQrefMeasure(),
+                    ConvertQssaDynMeasureToQrefDynMeasure(),
                 ]
             ),
             apply_recursively=False,

--- a/inconspiquous/transforms/convert_to_cme.py
+++ b/inconspiquous/transforms/convert_to_cme.py
@@ -46,7 +46,7 @@ class ToCMEPattern(RewritePattern):
         x = ConstantGateOp(XGate())
         i = ConstantGateOp(IdentityGate())
 
-        x_sel = arith.SelectOp(m.out[0], x, i)
+        x_sel = arith.SelectOp(m.outs[0], x, i)
 
         x_gate = qssa.DynGateOp(x_sel, cz.outs[1])
 

--- a/inconspiquous/transforms/randomized_comp.py
+++ b/inconspiquous/transforms/randomized_comp.py
@@ -277,7 +277,7 @@ class PadMeasure(RewritePattern):
 
         new_measure = MeasureOp(pre_z)
 
-        corrected_measure = AddiOp(x_rand, new_measure.out[0])
+        corrected_measure = AddiOp(x_rand, new_measure.outs[0])
 
         rewriter.insert_op(
             (

--- a/inconspiquous/transforms/xzs/commute.py
+++ b/inconspiquous/transforms/xzs/commute.py
@@ -60,7 +60,7 @@ class XZCommutePattern(RewritePattern):
 
             negate = CondNegateAngleOp(gate.x, angle)
             new_measurement = XYDynMeasurementOp(negate)
-            new_op2 = qssa.DynMeasureOp(new_measurement, op1.ins[0])
+            new_op2 = qssa.DynMeasureOp(op1.ins[0], measurement=new_measurement)
             new_op1 = arith.AddiOp(new_op2.outs[0], gate.z)
 
             rewriter.replace_op(
@@ -72,7 +72,7 @@ class XZCommutePattern(RewritePattern):
             if not isinstance(op2.measurement, CompBasisMeasurementAttr):
                 return
             new_op2 = qssa.MeasureOp(op1.ins[0])
-            new_op1 = arith.AddiOp(new_op2.out[0], gate.x)
+            new_op1 = arith.AddiOp(new_op2.outs[0], gate.x)
 
             rewriter.replace_op(op2, (new_op2, new_op1))
             rewriter.erase_op(op1)

--- a/inconspiquous/utils/qssa_builder.py
+++ b/inconspiquous/utils/qssa_builder.py
@@ -47,6 +47,6 @@ class QSSABuilder(Builder):
         if ImplicitBuilder.get() is None:
             self.insert(new_op)
         ref.qubit = None
-        out = new_op.out[0]
+        out = new_op.outs[0]
         out.name_hint = name_hint
         return out

--- a/tests/filecheck/transforms/convert_qref_to_qssa.mlir
+++ b/tests/filecheck/transforms/convert_qref_to_qssa.mlir
@@ -9,7 +9,8 @@ qref.gate<#gate.cx> %q0, %q1
 %0 = qref.measure %q0
 %g = gate.constant #gate.h
 qref.dyn_gate<%g> %q1
-%1 = qref.measure %q1
+%m = measurement.constant #measurement.comp_basis
+%1 = qref.dyn_measure<%m> %q1
 
 // CHECK:      %q0 = qubit.alloc
 // CHECK-NEXT: %q1 = qubit.alloc
@@ -19,7 +20,8 @@ qref.dyn_gate<%g> %q1
 // CHECK-NEXT: %{{.*}} = qssa.measure %q0_2
 // CHECK-NEXT: %g = gate.constant #gate.h
 // CHECK-NEXT: %q1_3 = qssa.dyn_gate<%g> %q1_2
-// CHECK-NEXT: %{{.*}} = qssa.measure %q1_3
+// CHECK-NEXT: %m = measurement.constant #measurement.comp_basis
+// CHECK-NEXT: %1 = qssa.dyn_measure<%m> %q1_3
 
 // CHECK-ROUNDTRIP:      %q0 = qubit.alloc
 // CHECK-ROUNDTRIP-NEXT: %q1 = qubit.alloc
@@ -29,7 +31,8 @@ qref.dyn_gate<%g> %q1
 // CHECK-ROUNDTRIP-NEXT: %{{.*}} = qref.measure %q0
 // CHECK-ROUNDTRIP-NEXT: %g = gate.constant #gate.h
 // CHECK-ROUNDTRIP-NEXT: qref.dyn_gate<%g> %q1
-// CHECK-ROUNDTRIP-NEXT: %{{.*}} = qref.measure %q1
+// CHECK-ROUNDTRIP-NEXT: %m = measurement.constant #measurement.comp_basis
+// CHECK-ROUNDTRIP-NEXT: %{{.*}} = qref.dyn_measure<%m> %q1
 
 func.func @qref_in_region(%q : !qubit.bit, %p: i1) -> !qubit.bit {
   %q2 = scf.if %p -> (!qubit.bit) {

--- a/tests/filecheck/transforms/convert_qssa_to_qref.mlir
+++ b/tests/filecheck/transforms/convert_qssa_to_qref.mlir
@@ -9,7 +9,8 @@
 %0 = qssa.measure %q4
 %g = gate.constant #gate.h
 %q6 = qssa.dyn_gate<%g> %q5
-%1 = qssa.measure %q6
+%m = measurement.constant #measurement.comp_basis
+%1 = qssa.dyn_measure<%m> %q6
 
 // CHECK:      %q0 = qubit.alloc
 // CHECK-NEXT: %q1 = qubit.alloc
@@ -19,7 +20,8 @@
 // CHECK-NEXT: %{{.*}} = qref.measure %q0
 // CHECK-NEXT: %g = gate.constant #gate.h
 // CHECK-NEXT: qref.dyn_gate<%g> %q1
-// CHECK-NEXT: %{{.*}} = qref.measure %q1
+// CHECK-NEXT: %m = measurement.constant #measurement.comp_basis
+// CHECK-NEXT: %{{.*}} = qref.dyn_measure<%m> %q1
 
 // CHECK-ROUNDTRIP:      %q0 = qubit.alloc
 // CHECK-ROUNDTRIP-NEXT: %q1 = qubit.alloc
@@ -29,4 +31,5 @@
 // CHECK-ROUNDTRIP-NEXT: %{{.*}} = qssa.measure %q0_2
 // CHECK-ROUNDTRIP-NEXT: %g = gate.constant #gate.h
 // CHECK-ROUNDTRIP-NEXT: %q1_3 = qssa.dyn_gate<%g> %q1_2
-// CHECK-ROUNDTRIP-NEXT: %{{.*}} = qssa.measure %q1_3
+// CHECK-ROUNDTRIP-NEXT: %m = measurement.constant #measurement.comp_basis
+// CHECK-ROUNDTRIP-NEXT: %{{.*}} = qssa.dyn_measure<%m> %q1_3


### PR DESCRIPTION
Missed this when adding dynamic measurement. Also renames `out` to `outs` on measure ops to standardise this and fixes the init method