### PR TITLE
Generalise Pauli Propagation. [Unitary Hack]

### DIFF
--- a/inconspiquous/dialects/gate.py
+++ b/inconspiquous/dialects/gate.py
@@ -45,6 +45,7 @@ from inconspiquous.dialects.angle import AngleAttr, AngleType
 from inconspiquous.gates import GateAttr, SingleQubitGate, TwoQubitGate
 from inconspiquous.constraints import SizedAttributeConstraint
 
+
 class CliffordGateAttr(GateAttr, ABC):
     """
     Abstract base class for Clifford gates that defines how Pauli operators
@@ -52,7 +53,9 @@ class CliffordGateAttr(GateAttr, ABC):
     """
 
     @abstractmethod
-    def pauli_prop(self, input_index: int, pauli_type: str) -> tuple[tuple[bool, bool], ...]:
+    def pauli_prop(
+        self, input_index: int, pauli_type: str
+    ) -> tuple[tuple[bool, bool], ...]:
         """
         Determines how a Pauli operator propagates through this gate.
 
@@ -62,13 +65,14 @@ class CliffordGateAttr(GateAttr, ABC):
 
         Returns:
             A tuple of tuples. Each inner tuple (bool, bool) represents the
-            (X_component, Z_component) of the Pauli operator on the corresponding 
+            (X_component, Z_component) of the Pauli operator on the corresponding
             output qubit.
 
-            Example: ((True, False), (False, True)) means X on the first output 
+            Example: ((True, False), (False, True)) means X on the first output
             qubit and Z on the second output qubit.
         """
         pass
+
 
 @irdl_attr_definition
 class GateType(ParametrizedAttribute, TypeAttribute):
@@ -145,9 +149,13 @@ class ConstantGateOp(IRDLOperation):
 class HadamardGate(SingleQubitGate, CliffordGateAttr):
     name = "gate.h"
 
-    def pauli_prop(self, input_index: int, pauli_type: str) -> tuple[tuple[bool, bool], ...]:
+    def pauli_prop(
+        self, input_index: int, pauli_type: str
+    ) -> tuple[tuple[bool, bool], ...]:
         if input_index != 0:
-            raise ValueError("HadamardGate is a single-qubit gate, input_index must be 0.")
+            raise ValueError(
+                "HadamardGate is a single-qubit gate, input_index must be 0."
+            )
 
         if pauli_type == "X":
             # X gate transforms to Z: X→H = H→Z
@@ -262,7 +270,9 @@ class DynJGate(IRDLOperation):
 class CXGate(TwoQubitGate, CliffordGateAttr):
     name = "gate.cx"
 
-    def pauli_prop(self, input_index: int, pauli_type: str) -> tuple[tuple[bool, bool], ...]:
+    def pauli_prop(
+        self, input_index: int, pauli_type: str
+    ) -> tuple[tuple[bool, bool], ...]:
         if input_index not in (0, 1):
             raise ValueError("CXGate is a two-qubit gate, input_index must be 0 or 1.")
 
@@ -283,11 +293,14 @@ class CXGate(TwoQubitGate, CliffordGateAttr):
         else:
             raise ValueError(f"pauli_type must be 'X' or 'Z', got {pauli_type}")
 
+
 @irdl_attr_definition
 class CZGate(TwoQubitGate, CliffordGateAttr):
     name = "gate.cz"
 
-    def pauli_prop(self, input_index: int, pauli_type: str) -> tuple[tuple[bool, bool], ...]:
+    def pauli_prop(
+        self, input_index: int, pauli_type: str
+    ) -> tuple[tuple[bool, bool], ...]:
         if input_index not in (0, 1):
             raise ValueError("CZGate is a two-qubit gate, input_index must be 0 or 1.")
 
@@ -307,6 +320,7 @@ class CZGate(TwoQubitGate, CliffordGateAttr):
                 return ((False, False), (False, True))
         else:
             raise ValueError(f"pauli_type must be 'X' or 'Z', got {pauli_type}")
+
 
 @irdl_attr_definition
 class ToffoliGate(GateAttr):

--- a/inconspiquous/transforms/xzs/commute.py
+++ b/inconspiquous/transforms/xzs/commute.py
@@ -11,9 +11,6 @@ from xdsl.pattern_rewriter import (
 from inconspiquous.dialects import qssa
 from inconspiquous.dialects.angle import AngleAttr, CondNegateAngleOp, ConstantAngleOp
 from inconspiquous.dialects.gate import (
-    CXGate,
-    CZGate,
-    HadamardGate,
     XZOp,
     CliffordGateAttr,
 )
@@ -25,13 +22,15 @@ from inconspiquous.dialects.measurement import (
 from inconspiquous.transforms.xzs.fusion import FuseXZGatesPattern
 from inconspiquous.utils.linear_walker import LinearWalker
 
+
 def _create_constant_bool(rewriter: PatternRewriter, value: bool) -> arith.ConstantOp:
     """Helper to create an i1 constant (boolean) value."""
     return rewriter.create_op(
-        arith.ConstantOp, 
-        properties={"value": IntegerAttr(1 if value else 0, i1)}, 
-        result_types=[i1]
+        arith.ConstantOp,
+        properties={"value": IntegerAttr(1 if value else 0, i1)},
+        result_types=[i1],
     )
+
 
 class XZCommutePattern(RewritePattern):
     """Commute an XZ gadget past a Hadamard/CX/CZ gate, or MeasureOp."""
@@ -103,7 +102,7 @@ class XZCommutePattern(RewritePattern):
                 qssa.GateOp,
                 properties={"gate": clifford},
                 operands=new_operands,
-                result_types=[out.type for out in op2.outs]
+                result_types=[out.type for out in op2.outs],
             )
             # Get propagation rules for X and Z inputs
             x_prop_rules = clifford.pauli_prop(input_index, "X")
@@ -131,9 +130,7 @@ class XZCommutePattern(RewritePattern):
                     if new_x is not None:
                         # Need to XOR with the existing value
                         new_x_op = rewriter.create_op(
-                            arith.XOrIOp,
-                            operands=[new_x, z_in],
-                            result_types=[i1]
+                            arith.XOrIOp, operands=[new_x, z_in], result_types=[i1]
                         )
                         new_ops.append(new_x_op)
                         new_x = new_x_op.results[0]
@@ -157,9 +154,7 @@ class XZCommutePattern(RewritePattern):
                     if new_z is not None:
                         # Need to XOR with the existing value
                         new_z_op = rewriter.create_op(
-                            arith.XOrIOp,
-                            operands=[new_z, z_in],
-                            result_types=[i1]
+                            arith.XOrIOp, operands=[new_z, z_in], result_types=[i1]
                         )
                         new_ops.append(new_z_op)
                         new_z = new_z_op.results[0]
@@ -174,7 +169,9 @@ class XZCommutePattern(RewritePattern):
                 new_xz_op = rewriter.create_op(
                     XZOp,
                     operands=[new_x, new_z],
-                    result_types=[gate.out.type]  # Same type as the original XZ operation
+                    result_types=[
+                        gate.out.type
+                    ],  # Same type as the original XZ operation
                 )
                 new_ops.append(new_xz_op)
 
@@ -182,7 +179,7 @@ class XZCommutePattern(RewritePattern):
                 new_dyn_gate = rewriter.create_op(
                     qssa.DynGateOp,
                     operands=[new_xz_op.results[0], output_qubit],
-                    result_types=[output_qubit.type]
+                    result_types=[output_qubit.type],
                 )
                 new_ops.append(new_dyn_gate)
                 results.append(new_dyn_gate.results[0])

--- a/inconspiquous/transforms/xzs/commute.py
+++ b/inconspiquous/transforms/xzs/commute.py
@@ -1,4 +1,5 @@
 from xdsl.dialects import arith, builtin
+from xdsl.dialects.builtin import IntegerAttr, i1
 from xdsl.parser import Context
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
@@ -14,6 +15,7 @@ from inconspiquous.dialects.gate import (
     CZGate,
     HadamardGate,
     XZOp,
+    CliffordGateAttr,
 )
 from inconspiquous.dialects.measurement import (
     CompBasisMeasurementAttr,
@@ -23,6 +25,13 @@ from inconspiquous.dialects.measurement import (
 from inconspiquous.transforms.xzs.fusion import FuseXZGatesPattern
 from inconspiquous.utils.linear_walker import LinearWalker
 
+def _create_constant_bool(rewriter: PatternRewriter, value: bool) -> arith.ConstantOp:
+    """Helper to create an i1 constant (boolean) value."""
+    return rewriter.create_op(
+        arith.ConstantOp, 
+        properties={"value": IntegerAttr(1 if value else 0, i1)}, 
+        result_types=[i1]
+    )
 
 class XZCommutePattern(RewritePattern):
     """Commute an XZ gadget past a Hadamard/CX/CZ gate, or MeasureOp."""
@@ -36,10 +45,9 @@ class XZCommutePattern(RewritePattern):
             return
 
         (use,) = op1.outs[0].uses
-
         op2 = use.operation
 
-        # Check for XY measurement
+        # Handle XY measurement case (unchanged)
         angle = None
         if isinstance(op2, qssa.DynMeasureOp) and isinstance(
             op2.measurement.owner, XYDynMeasurementOp
@@ -67,7 +75,9 @@ class XZCommutePattern(RewritePattern):
                 op2, (*angle_op, negate, new_measurement, new_op2, new_op1)
             )
             rewriter.erase_op(op1)
+            return
 
+        # Handle computational basis measurement case (unchanged)
         if isinstance(op2, qssa.MeasureOp):
             if not isinstance(op2.measurement, CompBasisMeasurementAttr):
                 return
@@ -76,67 +86,111 @@ class XZCommutePattern(RewritePattern):
 
             rewriter.replace_op(op2, (new_op2, new_op1))
             rewriter.erase_op(op1)
+            return
 
         if not isinstance(op2, qssa.GateOp):
             return
 
-        if isinstance(op2.gate, HadamardGate):
-            new_op2 = qssa.GateOp(HadamardGate(), *op1.ins)
-            new_gate = XZOp(gate.z, gate.x)
-            new_op1 = qssa.DynGateOp(new_gate, *new_op2.outs)
+        # Handle Clifford gates using pauli_prop
+        if isinstance(op2.gate, CliffordGateAttr):
+            clifford = op2.gate
+            input_index = use.index
+            x_in = gate.x
+            z_in = gate.z
+            new_operands = list(op2.ins)
+            new_operands[input_index] = op1.ins[0]
+            new_gate_op = rewriter.create_op(
+                qssa.GateOp,
+                properties={"gate": clifford},
+                operands=new_operands,
+                result_types=[out.type for out in op2.outs]
+            )
+            # Get propagation rules for X and Z inputs
+            x_prop_rules = clifford.pauli_prop(input_index, "X")
+            z_prop_rules = clifford.pauli_prop(input_index, "Z")
+            # Keep track of all new operations and output results
+            new_ops = [new_gate_op]
+            results = []
 
-            rewriter.replace_op(op2, (new_op2, new_gate, new_op1))
+            # Process each output qubit
+            for i, output_qubit in enumerate(new_gate_op.outs):
+                # How X input affects this output qubit: (X component, Z component)
+                x_from_x, z_from_x = x_prop_rules[i]
+
+                # How Z input affects this output qubit: (X component, Z component)
+                x_from_z, z_from_z = z_prop_rules[i]
+
+                new_x = None
+
+                # X component from input X
+                if x_from_x:
+                    new_x = x_in
+
+                # X component from input Z
+                if x_from_z:
+                    if new_x is not None:
+                        # Need to XOR with the existing value
+                        new_x_op = rewriter.create_op(
+                            arith.XOrIOp,
+                            operands=[new_x, z_in],
+                            result_types=[i1]
+                        )
+                        new_ops.append(new_x_op)
+                        new_x = new_x_op.results[0]
+                    else:
+                        new_x = z_in
+
+                # If no X component, use constant 0
+                if new_x is None:
+                    new_x = _create_constant_bool(rewriter, False).results[0]
+                    new_ops.append(new_x.owner)
+
+                # Create the necessary operations to compute new Z value
+                new_z = None
+
+                # Z component from input X
+                if z_from_x:
+                    new_z = x_in
+
+                # Z component from input Z
+                if z_from_z:
+                    if new_z is not None:
+                        # Need to XOR with the existing value
+                        new_z_op = rewriter.create_op(
+                            arith.XOrIOp,
+                            operands=[new_z, z_in],
+                            result_types=[i1]
+                        )
+                        new_ops.append(new_z_op)
+                        new_z = new_z_op.results[0]
+                    else:
+                        new_z = z_in
+
+                # If no Z component, use constant 0
+                if new_z is None:
+                    new_z = _create_constant_bool(rewriter, False).results[0]
+                    new_ops.append(new_z.owner)
+
+                new_xz_op = rewriter.create_op(
+                    XZOp,
+                    operands=[new_x, new_z],
+                    result_types=[gate.out.type]  # Same type as the original XZ operation
+                )
+                new_ops.append(new_xz_op)
+
+                # Apply the new XZ operation to the output qubit
+                new_dyn_gate = rewriter.create_op(
+                    qssa.DynGateOp,
+                    operands=[new_xz_op.results[0], output_qubit],
+                    result_types=[output_qubit.type]
+                )
+                new_ops.append(new_dyn_gate)
+                results.append(new_dyn_gate.results[0])
+
+            # Replace the original gate operation with our new sequence
+            rewriter.replace_op(op2, new_ops, results)
             rewriter.erase_op(op1)
-
-        if isinstance(op2.gate, CXGate):
-            c0 = arith.ConstantOp.from_int_and_width(0, 1)
-            if use.index == 0:
-                new_op2 = qssa.GateOp(CXGate(), *(op1.ins[0], op2.ins[1]))
-                new_op1_left = qssa.DynGateOp(gate, new_op2.outs[0])
-                new_gate_right = XZOp(gate.x, c0)
-                new_op1_right = qssa.DynGateOp(new_gate_right, new_op2.outs[1])
-                rewriter.replace_op(
-                    op2,
-                    (c0, new_op2, new_op1_left, new_gate_right, new_op1_right),
-                    (new_op1_left.outs[0], new_op1_right.outs[0]),
-                )
-                rewriter.erase_op(op1)
-            elif use.index == 1:
-                new_op2 = qssa.GateOp(CXGate(), *(op2.ins[0], op1.ins[0]))
-                new_gate_left = XZOp(c0, gate.z)
-                new_op1_left = qssa.DynGateOp(new_gate_left, new_op2.outs[0])
-                new_op1_right = qssa.DynGateOp(gate, new_op2.outs[1])
-                rewriter.replace_op(
-                    op2,
-                    (c0, new_op2, new_gate_left, new_op1_left, new_op1_right),
-                    (new_op1_left.outs[0], new_op1_right.outs[0]),
-                )
-                rewriter.erase_op(op1)
-
-        if isinstance(op2.gate, CZGate):
-            c0 = arith.ConstantOp.from_int_and_width(0, 1)
-            if use.index == 0:
-                new_op2 = qssa.GateOp(CZGate(), *(op1.ins[0], op2.ins[1]))
-                new_op1_left = qssa.DynGateOp(gate, new_op2.outs[0])
-                new_gate_right = XZOp(c0, gate.x)
-                new_op1_right = qssa.DynGateOp(new_gate_right, new_op2.outs[1])
-                rewriter.replace_op(
-                    op2,
-                    (c0, new_op2, new_op1_left, new_gate_right, new_op1_right),
-                    (new_op1_left.outs[0], new_op1_right.outs[0]),
-                )
-                rewriter.erase_op(op1)
-            elif use.index == 1:
-                new_op2 = qssa.GateOp(CZGate(), *(op2.ins[0], op1.ins[0]))
-                new_gate_left = XZOp(c0, gate.x)
-                new_op1_left = qssa.DynGateOp(new_gate_left, new_op2.outs[0])
-                new_op1_right = qssa.DynGateOp(gate, new_op2.outs[1])
-                rewriter.replace_op(
-                    op2,
-                    (c0, new_op2, new_gate_left, new_op1_left, new_op1_right),
-                    (new_op1_left.outs[0], new_op1_right.outs[0]),
-                )
-                rewriter.erase_op(op1)
+            return
 
 
 class XZCommute(ModulePass):


### PR DESCRIPTION
This PR generalizes the Pauli propagation logic within the `XZCommutePattern` transformation.

**Key Changes:**

*   **Introduced `CliffordGateAttr`:**
    *   Defined a new abstract base class (or mixin) `CliffordGateAttr` inheriting from `GateAttr`.
    *   This class introduces an abstract method `pauli_prop(self, input_index: int, pauli_type: str) -> tuple[tuple[bool, bool], ...]`.
    *   `pauli_prop` defines how an input Pauli X or Z on a specific input qubit propagates to X and Z components on each of the gate's output qubits.
*   **Implemented `pauli_prop` for Clifford Gates:**
    *   `HadamardGate`, `CXGate`, and `CZGate` now inherit from `CliffordGateAttr` and implement the `pauli_prop` method according to their respective commutation rules.
    *   For example:
        *   `HadamardGate.pauli_prop(0, "X")` returns `((False, True),)` (X -> H = H -> Z).
        *   `CXGate.pauli_prop(0, "X")` returns `((True, False), (True, False))` (X on control propagates to X on both outputs).
*   **Refactored `XZCommutePattern`:**
    *   The pattern in `inconspiquous.transforms.xzs.commute.py` has been updated to use the `pauli_prop` method from `CliffordGateAttr`.
    *   Instead of hardcoded logic for specific gates (H, CX, CZ), it now dynamically queries the propagation rules if the gate is an instance of `CliffordGateAttr`.
    *   The pattern constructs the necessary `arith.AndIOp` and `arith.XOrIOp` operations to compute the resulting Pauli X and Z components on the output qubits.

**Motivation:**

*   **Extensibility:** This change allows new user-defined gates to participate in Pauli propagation by simply implementing the `CliffordGateAttr` interface.
*   **Maintainability:** Centralizes Pauli propagation logic, making it easier to understand and modify.
*   **Future-proofing:** Lays the groundwork for potentially supporting Pauli propagation for dynamic gates or more complex Clifford operations in the future.
