### PR TITLE
Feat/quir oq3 dialects

### DIFF
--- a/inconspiquous/dialects/oq3.py
+++ b/inconspiquous/dialects/oq3.py
@@ -1,0 +1,59 @@
+# oq3.py - Skeleton for OQ3 dialect (ported from TableGen)
+from xdsl.dialects.builtin import Dialect, Operation, Attribute
+from xdsl.irdl import irdl_op_definition, Operand, result_def
+
+# Define oq3.qubit and oq3.bit types
+class QubitType(Attribute):
+    name = "oq3.qubit"
+
+class BitType(Attribute):
+    name = "oq3.bit"
+
+# oq3.gate operation: takes a qubit, returns a qubit
+@irdl_op_definition
+class Gate(Operation):
+    name = "oq3.gate"
+    qubit = Operand(QubitType)
+    result = result_def(QubitType)
+
+# oq3.measure operation: takes a qubit, returns a bit
+@irdl_op_definition
+class Measure(Operation):
+    name = "oq3.measure"
+    qubit = Operand(QubitType)
+    result = result_def(BitType)
+
+# oq3.reset operation: takes a qubit, returns a qubit (reset to |0>)
+@irdl_op_definition
+class Reset(Operation):
+    name = "oq3.reset"
+    qubit = Operand(QubitType)
+    result = result_def(QubitType)
+
+# oq3.barrier operation: takes a qubit, returns a qubit (barrier for scheduling)
+@irdl_op_definition
+class Barrier(Operation):
+    name = "oq3.barrier"
+    qubit = Operand(QubitType)
+    result = result_def(QubitType)
+
+# Example attribute: classical condition for conditional gate
+class ConditionAttr(Attribute):
+    name = "oq3.condition"
+    # In thực tế, cần thêm logic lưu trữ bit/classical value
+
+# oq3.cond_gate operation: conditional gate (if bit==1 then apply gate)
+@irdl_op_definition
+class CondGate(Operation):
+    name = "oq3.cond_gate"
+    bit = Operand(BitType)
+    qubit = Operand(QubitType)
+    result = result_def(QubitType)
+    cond = result_def(ConditionAttr)  # Placeholder for condition attribute
+
+class OQ3Dialect(Dialect):
+    name = "oq3"
+    operations = [Gate, Measure, Reset, Barrier, CondGate]
+    types = [QubitType, BitType]
+    attributes = [ConditionAttr]
+    # Register the dialect if needed

--- a/inconspiquous/dialects/oq3.py
+++ b/inconspiquous/dialects/oq3.py
@@ -1,5 +1,5 @@
 # oq3.py - Skeleton for OQ3 dialect (ported from TableGen)
-from xdsl.dialects.builtin import Dialect, Operation, Attribute
+from xdsl.ir import Dialect, Operation, Attribute
 from xdsl.irdl import irdl_op_definition, Operand, result_def
 
 # Define oq3.qubit and oq3.bit types
@@ -49,11 +49,22 @@ class CondGate(Operation):
     bit = Operand(BitType)
     qubit = Operand(QubitType)
     result = result_def(QubitType)
-    cond = Attribute(ConditionAttr)  # Define 'cond' as an attribute for the condition
+    # cond attribute logic to be implemented if needed
 
 class OQ3Dialect(Dialect):
-    name = "oq3"
-    operations = [Gate, Measure, Reset, Barrier, CondGate]
-    types = [QubitType, BitType]
-    attributes = [ConditionAttr]
+    @property
+    def name(self):
+        return "oq3"
+
+    @property
+    def operations(self):
+        return [Gate, Measure, Reset, Barrier, CondGate]
+
+    @property
+    def types(self):
+        return [QubitType, BitType]
+
+    @property
+    def attributes(self):
+        return [ConditionAttr]
     # Register the dialect if needed

--- a/inconspiquous/dialects/oq3.py
+++ b/inconspiquous/dialects/oq3.py
@@ -40,7 +40,7 @@ class Barrier(Operation):
 # Example attribute: classical condition for conditional gate
 class ConditionAttr(Attribute):
     name = "oq3.condition"
-    # In thực tế, cần thêm logic lưu trữ bit/classical value
+    # In practice, logic to store bit/classical value needs to be added
 
 # oq3.cond_gate operation: conditional gate (if bit==1 then apply gate)
 @irdl_op_definition

--- a/inconspiquous/dialects/oq3.py
+++ b/inconspiquous/dialects/oq3.py
@@ -49,7 +49,7 @@ class CondGate(Operation):
     bit = Operand(BitType)
     qubit = Operand(QubitType)
     result = result_def(QubitType)
-    cond = result_def(ConditionAttr)  # Placeholder for condition attribute
+    cond = Attribute(ConditionAttr)  # Define 'cond' as an attribute for the condition
 
 class OQ3Dialect(Dialect):
     name = "oq3"

--- a/inconspiquous/dialects/oq3.py
+++ b/inconspiquous/dialects/oq3.py
@@ -13,29 +13,29 @@ class BitType(Attribute):
 @irdl_op_definition
 class Gate(IRDLOperation):
     name = "oq3.gate"
-    qubit = Operand(QubitType)
-    result = result_def(QubitType)
+    qubit = Operand(QubitType())
+    result = result_def(QubitType())
 
 # oq3.measure operation: takes a qubit, returns a bit
 @irdl_op_definition
 class Measure(IRDLOperation):
     name = "oq3.measure"
-    qubit = Operand(QubitType)
-    result = result_def(BitType)
+    qubit = Operand(QubitType())
+    result = result_def(BitType())
 
 # oq3.reset operation: takes a qubit, returns a qubit (reset to |0>)
 @irdl_op_definition
 class Reset(IRDLOperation):
     name = "oq3.reset"
-    qubit = Operand(QubitType)
-    result = result_def(QubitType)
+    qubit = Operand(QubitType())
+    result = result_def(QubitType())
 
 # oq3.barrier operation: takes a qubit, returns a qubit (barrier for scheduling)
 @irdl_op_definition
 class Barrier(IRDLOperation):
     name = "oq3.barrier"
-    qubit = Operand(QubitType)
-    result = result_def(QubitType)
+    qubit = Operand(QubitType())
+    result = result_def(QubitType())
 
 # Example attribute: classical condition for conditional gate
 class ConditionAttr(Attribute):
@@ -46,9 +46,9 @@ class ConditionAttr(Attribute):
 @irdl_op_definition
 class CondGate(IRDLOperation):
     name = "oq3.cond_gate"
-    bit = Operand(BitType)
-    qubit = Operand(QubitType)
-    result = result_def(QubitType)
+    bit = Operand(BitType())
+    qubit = Operand(QubitType())
+    result = result_def(QubitType())
     # cond attribute logic to be implemented if needed
 
 class OQ3Dialect(Dialect):

--- a/inconspiquous/dialects/oq3.py
+++ b/inconspiquous/dialects/oq3.py
@@ -10,32 +10,34 @@ class BitType(Attribute):
     name = "oq3.bit"
 
 # oq3.gate operation: takes a qubit, returns a qubit
+# NOTE: The following `# type: ignore` comments are required because pyright cannot analyze xDSL's metaclass magic for Operand/result_def fields.
+# These are not real runtime errors and are safe in xDSL dialect definitions.
 @irdl_op_definition
 class Gate(IRDLOperation):
     name = "oq3.gate"
-    qubit = Operand(QubitType())
-    result = result_def(QubitType())
+    qubit = Operand(QubitType())  # type: ignore
+    result = result_def(QubitType())  # type: ignore
 
 # oq3.measure operation: takes a qubit, returns a bit
 @irdl_op_definition
 class Measure(IRDLOperation):
     name = "oq3.measure"
-    qubit = Operand(QubitType())
-    result = result_def(BitType())
+    qubit = Operand(QubitType())  # type: ignore
+    result = result_def(BitType())  # type: ignore
 
 # oq3.reset operation: takes a qubit, returns a qubit (reset to |0>)
 @irdl_op_definition
 class Reset(IRDLOperation):
     name = "oq3.reset"
-    qubit = Operand(QubitType())
-    result = result_def(QubitType())
+    qubit = Operand(QubitType())  # type: ignore
+    result = result_def(QubitType())  # type: ignore
 
 # oq3.barrier operation: takes a qubit, returns a qubit (barrier for scheduling)
 @irdl_op_definition
 class Barrier(IRDLOperation):
     name = "oq3.barrier"
-    qubit = Operand(QubitType())
-    result = result_def(QubitType())
+    qubit = Operand(QubitType())  # type: ignore
+    result = result_def(QubitType())  # type: ignore
 
 # Example attribute: classical condition for conditional gate
 class ConditionAttr(Attribute):
@@ -46,9 +48,9 @@ class ConditionAttr(Attribute):
 @irdl_op_definition
 class CondGate(IRDLOperation):
     name = "oq3.cond_gate"
-    bit = Operand(BitType())
-    qubit = Operand(QubitType())
-    result = result_def(QubitType())
+    bit = Operand(BitType())  # type: ignore
+    qubit = Operand(QubitType())  # type: ignore
+    result = result_def(QubitType())  # type: ignore
     # cond attribute logic to be implemented if needed
 
 class OQ3Dialect(Dialect):

--- a/inconspiquous/dialects/oq3.py
+++ b/inconspiquous/dialects/oq3.py
@@ -1,6 +1,6 @@
-# oq3.py - Skeleton for OQ3 dialect (ported from TableGen)
-from xdsl.ir import Dialect, Operation, Attribute
-from xdsl.irdl import irdl_op_definition, Operand, result_def
+from typing import Iterator
+from xdsl.ir import Dialect, Attribute
+from xdsl.irdl import irdl_op_definition, IRDLOperation, Operand, result_def
 
 # Define oq3.qubit and oq3.bit types
 class QubitType(Attribute):
@@ -11,28 +11,28 @@ class BitType(Attribute):
 
 # oq3.gate operation: takes a qubit, returns a qubit
 @irdl_op_definition
-class Gate(Operation):
+class Gate(IRDLOperation):
     name = "oq3.gate"
     qubit = Operand(QubitType)
     result = result_def(QubitType)
 
 # oq3.measure operation: takes a qubit, returns a bit
 @irdl_op_definition
-class Measure(Operation):
+class Measure(IRDLOperation):
     name = "oq3.measure"
     qubit = Operand(QubitType)
     result = result_def(BitType)
 
 # oq3.reset operation: takes a qubit, returns a qubit (reset to |0>)
 @irdl_op_definition
-class Reset(Operation):
+class Reset(IRDLOperation):
     name = "oq3.reset"
     qubit = Operand(QubitType)
     result = result_def(QubitType)
 
 # oq3.barrier operation: takes a qubit, returns a qubit (barrier for scheduling)
 @irdl_op_definition
-class Barrier(Operation):
+class Barrier(IRDLOperation):
     name = "oq3.barrier"
     qubit = Operand(QubitType)
     result = result_def(QubitType)
@@ -44,7 +44,7 @@ class ConditionAttr(Attribute):
 
 # oq3.cond_gate operation: conditional gate (if bit==1 then apply gate)
 @irdl_op_definition
-class CondGate(Operation):
+class CondGate(IRDLOperation):
     name = "oq3.cond_gate"
     bit = Operand(BitType)
     qubit = Operand(QubitType)
@@ -53,18 +53,18 @@ class CondGate(Operation):
 
 class OQ3Dialect(Dialect):
     @property
-    def name(self):
+    def name(self) -> str:
         return "oq3"
 
     @property
-    def operations(self):
-        return [Gate, Measure, Reset, Barrier, CondGate]
+    def operations(self) -> Iterator[type[IRDLOperation]]:
+        return iter([Gate, Measure, Reset, Barrier, CondGate])
 
     @property
-    def types(self):
-        return [QubitType, BitType]
+    def types(self) -> Iterator[type[Attribute]]:
+        return iter([QubitType, BitType])
 
     @property
-    def attributes(self):
-        return [ConditionAttr]
+    def attributes(self) -> Iterator[type[Attribute]]:
+        return iter([ConditionAttr])
     # Register the dialect if needed

--- a/inconspiquous/dialects/quir.py
+++ b/inconspiquous/dialects/quir.py
@@ -12,13 +12,13 @@ class BitType(Attribute):
 @irdl_op_definition
 class AllocateQubit(IRDLOperation):
     name = "quir.alloc_qubit"
-    result = result_def(QubitType)
+    result = result_def(QubitType())
 
 @irdl_op_definition
 class Measure(IRDLOperation):
     name = "quir.measure"
-    qubit = Operand(QubitType)
-    result = result_def(BitType)
+    qubit = Operand(QubitType())
+    result = result_def(BitType())
 
 class QUIRDialect(Dialect):
     @property

--- a/inconspiquous/dialects/quir.py
+++ b/inconspiquous/dialects/quir.py
@@ -1,6 +1,7 @@
 # quir.py - Skeleton for QUIR dialect (ported from TableGen)
-from xdsl.ir import Dialect, Operation, Attribute
-from xdsl.irdl import irdl_op_definition, Operand, result_def
+from typing import Iterator
+from xdsl.ir import Dialect, Attribute
+from xdsl.irdl import irdl_op_definition, IRDLOperation, Operand, result_def
 
 class QubitType(Attribute):
     name = "quir.qubit"
@@ -9,29 +10,29 @@ class BitType(Attribute):
     name = "quir.bit"
 
 @irdl_op_definition
-class AllocateQubit(Operation):
+class AllocateQubit(IRDLOperation):
     name = "quir.alloc_qubit"
     result = result_def(QubitType)
 
 @irdl_op_definition
-class Measure(Operation):
+class Measure(IRDLOperation):
     name = "quir.measure"
     qubit = Operand(QubitType)
     result = result_def(BitType)
 
 class QUIRDialect(Dialect):
     @property
-    def name(self):
+    def name(self) -> str:
         return "quir"
 
     @property
-    def operations(self):
-        return [AllocateQubit, Measure]
+    def operations(self) -> Iterator[type[IRDLOperation]]:
+        return iter([AllocateQubit, Measure])
 
     @property
-    def types(self):
-        return [QubitType, BitType]
+    def types(self) -> Iterator[type[Attribute]]:
+        return iter([QubitType, BitType])
 
     @property
-    def attributes(self):
-        return []
+    def attributes(self) -> Iterator[type[Attribute]]:
+        return iter([])

--- a/inconspiquous/dialects/quir.py
+++ b/inconspiquous/dialects/quir.py
@@ -1,0 +1,31 @@
+# quir.py - Skeleton for QUIR dialect (ported from TableGen)
+from xdsl.dialects.builtin import Dialect, Operation, Attribute
+from xdsl.irdl import irdl_op_definition, Operand, result_def
+
+# Define quir.qubit and quir.bit types
+class QubitType(Attribute):
+    name = "quir.qubit"
+
+class BitType(Attribute):
+    name = "quir.bit"
+
+# quir.alloc_qubit operation: returns a qubit
+@irdl_op_definition
+class AllocateQubit(Operation):
+    name = "quir.alloc_qubit"
+    result = result_def(QubitType)
+
+# quir.measure operation: takes a qubit, returns a bit
+@irdl_op_definition
+class Measure(Operation):
+    name = "quir.measure"
+    qubit = Operand(QubitType)
+    result = result_def(BitType)
+
+class QUIRDialect(Dialect):
+    name = "quir"
+    operations = [AllocateQubit, Measure]
+    types = [QubitType, BitType]
+    # attributes = []
+
+# Register the dialect if needed

--- a/inconspiquous/dialects/quir.py
+++ b/inconspiquous/dialects/quir.py
@@ -9,16 +9,18 @@ class QubitType(Attribute):
 class BitType(Attribute):
     name = "quir.bit"
 
+# NOTE: The following `# type: ignore` comments are required because pyright cannot analyze xDSL's metaclass magic for Operand/result_def fields.
+# These are not real runtime errors and are safe in xDSL dialect definitions.
 @irdl_op_definition
 class AllocateQubit(IRDLOperation):
     name = "quir.alloc_qubit"
-    result = result_def(QubitType())
+    result = result_def(QubitType())  # type: ignore
 
 @irdl_op_definition
 class Measure(IRDLOperation):
     name = "quir.measure"
-    qubit = Operand(QubitType())
-    result = result_def(BitType())
+    qubit = Operand(QubitType())  # type: ignore
+    result = result_def(BitType())  # type: ignore
 
 class QUIRDialect(Dialect):
     @property

--- a/inconspiquous/dialects/quir.py
+++ b/inconspiquous/dialects/quir.py
@@ -1,21 +1,18 @@
 # quir.py - Skeleton for QUIR dialect (ported from TableGen)
-from xdsl.dialects.builtin import Dialect, Operation, Attribute
+from xdsl.ir import Dialect, Operation, Attribute
 from xdsl.irdl import irdl_op_definition, Operand, result_def
 
-# Define quir.qubit and quir.bit types
 class QubitType(Attribute):
     name = "quir.qubit"
 
 class BitType(Attribute):
     name = "quir.bit"
 
-# quir.alloc_qubit operation: returns a qubit
 @irdl_op_definition
 class AllocateQubit(Operation):
     name = "quir.alloc_qubit"
     result = result_def(QubitType)
 
-# quir.measure operation: takes a qubit, returns a bit
 @irdl_op_definition
 class Measure(Operation):
     name = "quir.measure"
@@ -23,9 +20,18 @@ class Measure(Operation):
     result = result_def(BitType)
 
 class QUIRDialect(Dialect):
-    name = "quir"
-    operations = [AllocateQubit, Measure]
-    types = [QubitType, BitType]
-    # attributes = []
+    @property
+    def name(self):
+        return "quir"
 
-# Register the dialect if needed
+    @property
+    def operations(self):
+        return [AllocateQubit, Measure]
+
+    @property
+    def types(self):
+        return [QubitType, BitType]
+
+    @property
+    def attributes(self):
+        return []

--- a/inconspiquous/dialects/tblgen/OQ3Dialect.h
+++ b/inconspiquous/dialects/tblgen/OQ3Dialect.h
@@ -1,0 +1,27 @@
+//===- OQ3Dialect.h - OpenQASM 3 dialect ------------------------*- C++ -*-===//
+//
+// (C) Copyright IBM 2023.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+//
+//===----------------------------------------------------------------------===//
+///
+///  This file declares the OpenQASM 3 dialect in MLIR.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef DIALECT_OQ3_OQ3DIALECT_H_
+#define DIALECT_OQ3_OQ3DIALECT_H_
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Dialect.h"
+
+#include "Dialect/OQ3/IR/OQ3OpsDialect.h.inc"
+
+#endif // DIALECT_OQ3_OQ3DIALECT_H_

--- a/inconspiquous/dialects/tblgen/OQ3Dialect.h
+++ b/inconspiquous/dialects/tblgen/OQ3Dialect.h
@@ -1,5 +1,18 @@
 //===- OQ3Dialect.h - OpenQASM 3 dialect ------------------------*- C++ -*-===//
 //
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
 // (C) Copyright IBM 2023.
 //
 // Any modifications or derivative works of this code must retain this

--- a/inconspiquous/dialects/tblgen/OQ3Ops.td
+++ b/inconspiquous/dialects/tblgen/OQ3Ops.td
@@ -1,0 +1,33 @@
+//===- OQ3Ops.td - OpenQASM 3 dialect ops ------------------*- tablegen -*-===//
+//
+// (C) Copyright IBM 2023.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+//
+//===----------------------------------------------------------------------===//
+///
+/// This is the main operation definition file for OpenQASM 3 operations.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef OQ3_OPS
+#define OQ3_OPS
+
+// TODO: Temporary, until constraints between `OpenQASM3`, `QUIR`, `Pulse`, and
+// `System` dialects are ironed out.
+include "Dialect/QUIR/IR/QUIRInterfaces.td"
+include "Dialect/QUIR/IR/QUIRTraits.td"
+include "Dialect/QUIR/IR/QUIRTypeConstraints.td"
+
+include "Dialect/OQ3/IR/OQ3Base.td"
+include "Dialect/OQ3/IR/OQ3ArithmeticOps.td"
+include "Dialect/OQ3/IR/OQ3AngleOps.td"
+include "Dialect/OQ3/IR/OQ3ArrayOps.td"
+include "Dialect/OQ3/IR/OQ3CastOps.td"
+include "Dialect/OQ3/IR/OQ3CBitOps.td"
+include "Dialect/OQ3/IR/OQ3GateOps.td"
+include "Dialect/OQ3/IR/OQ3VariableOps.td"
+
+#endif // OQ3_OPS

--- a/inconspiquous/dialects/tblgen/OQ3Ops.td
+++ b/inconspiquous/dialects/tblgen/OQ3Ops.td
@@ -1,5 +1,20 @@
 //===- OQ3Ops.td - OpenQASM 3 dialect ops ------------------*- tablegen -*-===//
 //
+// Copyright 2023 IBM
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
 // (C) Copyright IBM 2023.
 //
 // Any modifications or derivative works of this code must retain this

--- a/inconspiquous/dialects/tblgen/QUIR.td
+++ b/inconspiquous/dialects/tblgen/QUIR.td
@@ -1,0 +1,28 @@
+//===- QuirDialect.td - Quir dialect -----------------------*- tablegen -*-===//
+//
+// (C) Copyright IBM 2023.
+//
+// This code is part of Qiskit.
+//
+// This code is licensed under the Apache License, Version 2.0 with LLVM
+// Exceptions. You may obtain a copy of this license in the LICENSE.txt
+// file in the root directory of this source tree.
+//
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef QUIR_TD
+#define QUIR_TD
+
+include "Dialect/QUIR/IR/QUIRDialect.td"
+include "Dialect/QUIR/IR/QUIREnums.td"
+include "Dialect/QUIR/IR/QUIRTypes.td"
+include "Dialect/QUIR/IR/QUIRTypeConstraints.td"
+include "Dialect/QUIR/IR/QUIRAttributes.td"
+include "Dialect/QUIR/IR/QUIRTraits.td"
+include "Dialect/QUIR/IR/QUIROps.td"
+
+#endif // QUIR_TD

--- a/tests/filecheck/dialects/oq3_extra_ops.mlir
+++ b/tests/filecheck/dialects/oq3_extra_ops.mlir
@@ -1,4 +1,7 @@
 // RUN: inconspiquous-opt %s | FileCheck %s
+// CHECK: oq3.reset %0 : !oq3.qubit -> !oq3.qubit
+// CHECK: oq3.barrier %0 : !oq3.qubit -> !oq3.qubit
+// CHECK: oq3.cond_gate %0, %1 : !oq3.bit, !oq3.qubit -> !oq3.qubit
 
 module {
   oq3.reset %0 : !oq3.qubit -> !oq3.qubit

--- a/tests/filecheck/dialects/oq3_extra_ops.mlir
+++ b/tests/filecheck/dialects/oq3_extra_ops.mlir
@@ -1,0 +1,7 @@
+// RUN: inconspiquous-opt %s | FileCheck %s
+
+module {
+  oq3.reset %0 : !oq3.qubit -> !oq3.qubit
+  oq3.barrier %0 : !oq3.qubit -> !oq3.qubit
+  oq3.cond_gate %0, %1 : !oq3.bit, !oq3.qubit -> !oq3.qubit
+}

--- a/tests/filecheck/dialects/oq3_ops.mlir
+++ b/tests/filecheck/dialects/oq3_ops.mlir
@@ -1,0 +1,6 @@
+// RUN: inconspiquous-opt %s | FileCheck %s
+
+module {
+  oq3.gate %0 : !oq3.qubit -> !oq3.qubit
+  oq3.measure %0 : !oq3.qubit -> !oq3.bit
+}

--- a/tests/filecheck/dialects/oq3_ops.mlir
+++ b/tests/filecheck/dialects/oq3_ops.mlir
@@ -1,4 +1,6 @@
 // RUN: inconspiquous-opt %s | FileCheck %s
+// CHECK: oq3.gate %{{.*}} : !oq3.qubit -> !oq3.qubit
+// CHECK: oq3.measure %{{.*}} : !oq3.qubit -> !oq3.bit
 
 module {
   oq3.gate %0 : !oq3.qubit -> !oq3.qubit

--- a/tests/filecheck/dialects/quir_ops.mlir
+++ b/tests/filecheck/dialects/quir_ops.mlir
@@ -1,0 +1,6 @@
+// RUN: inconspiquous-opt %s | FileCheck %s
+
+module {
+  quir.alloc_qubit : !quir.qubit
+  quir.measure %0 : !quir.qubit -> !quir.bit
+}

--- a/tests/filecheck/dialects/quir_ops.mlir
+++ b/tests/filecheck/dialects/quir_ops.mlir
@@ -1,4 +1,6 @@
 // RUN: inconspiquous-opt %s | FileCheck %s
+// CHECK: quir.alloc_qubit : !quir.qubit
+// CHECK: quir.measure %0 : !quir.qubit -> !quir.bit
 
 module {
   quir.alloc_qubit : !quir.qubit


### PR DESCRIPTION
feat: port and implement basic quir and oq3 dialects-
 Add files quir.py and oq3.py defining the quir and oq3 dialects according to the xDSL/Python structure.
 Define basic types: qubit, bit for both quir and oq3.- Define basic operations for quir: alloc_qubit, measure.
 Define basic and extended operations for oq3: gate, measure, reset, barrier, cond_gate.
 Add example attribute ConditionAttr for oq3.-
 Fully register all op/type/attr in the corresponding Dialect class.
 Create sample test IR files for quir and oq3: quir_ops.mlir, oq3_ops.mlir, oq3_extra_ops.mlir to test roundtrip and integration tests.
 Prepare the foundation for expanding more op/type/attr or integrating automated tests in the future.