### PR TITLE
transforms: (xz-commute) use NamedTuple for pauli prop

### DIFF
--- a/inconspiquous/dialects/gate.py
+++ b/inconspiquous/dialects/gate.py
@@ -48,6 +48,7 @@ from inconspiquous.gates import (
     SingleQubitGate,
 )
 from inconspiquous.constraints import SizedAttributeConstraint
+from inconspiquous.gates.core import PauliProp
 
 
 @irdl_attr_definition
@@ -127,12 +128,12 @@ class HadamardGate(SingleQubitCliffordGate):
 
     def pauli_prop(
         self, input_idx: int, pauli_type: Literal["X", "Z"]
-    ) -> tuple[tuple[bool, bool], ...]:
+    ) -> tuple[PauliProp, ...]:
         assert input_idx == 0
         if pauli_type == "X":
-            return ((False, True),)
+            return (PauliProp(False, True),)
         else:
-            return ((True, False),)
+            return (PauliProp(True, False),)
 
 
 @irdl_attr_definition
@@ -141,12 +142,12 @@ class XGate(SingleQubitCliffordGate):
 
     def pauli_prop(
         self, input_idx: int, pauli_type: Literal["X", "Z"]
-    ) -> tuple[tuple[bool, bool], ...]:
+    ) -> tuple[PauliProp, ...]:
         assert input_idx == 0
         if pauli_type == "X":
-            return ((True, False),)
+            return (PauliProp(True, False),)
         else:
-            return ((False, True),)
+            return (PauliProp(False, True),)
 
 
 @irdl_attr_definition
@@ -155,12 +156,12 @@ class YGate(SingleQubitCliffordGate):
 
     def pauli_prop(
         self, input_idx: int, pauli_type: Literal["X", "Z"]
-    ) -> tuple[tuple[bool, bool], ...]:
+    ) -> tuple[PauliProp, ...]:
         assert input_idx == 0
         if pauli_type == "X":
-            return ((True, True),)
+            return (PauliProp(True, False),)
         else:
-            return ((True, True),)
+            return (PauliProp(False, True),)
 
 
 @irdl_attr_definition
@@ -169,12 +170,12 @@ class ZGate(SingleQubitCliffordGate):
 
     def pauli_prop(
         self, input_idx: int, pauli_type: Literal["X", "Z"]
-    ) -> tuple[tuple[bool, bool], ...]:
+    ) -> tuple[PauliProp, ...]:
         assert input_idx == 0
         if pauli_type == "X":
-            return ((True, False),)
+            return (PauliProp(True, False),)
         else:
-            return ((False, True),)
+            return (PauliProp(False, True),)
 
 
 @irdl_attr_definition
@@ -267,23 +268,23 @@ class CXGate(TwoQubitCliffordGate):
 
     def pauli_prop(
         self, input_idx: int, pauli_type: Literal["X", "Z"]
-    ) -> tuple[tuple[bool, bool], ...]:
+    ) -> tuple[PauliProp, ...]:
         if pauli_type == "X":
             if input_idx == 0:
-                return ((True, False), (True, False))
+                return (PauliProp(True, False), PauliProp(True, False))
             else:
                 return (
-                    (False, False),
-                    (True, False),
+                    PauliProp(False, False),
+                    PauliProp(True, False),
                 )
         else:
             if input_idx == 0:
                 return (
-                    (False, True),
-                    (False, False),
+                    PauliProp(False, True),
+                    PauliProp(False, False),
                 )
             else:
-                return ((False, True), (False, True))
+                return (PauliProp(False, True), PauliProp(False, True))
 
 
 @irdl_attr_definition
@@ -292,25 +293,25 @@ class CZGate(TwoQubitCliffordGate):
 
     def pauli_prop(
         self, input_idx: int, pauli_type: Literal["X", "Z"]
-    ) -> tuple[tuple[bool, bool], ...]:
+    ) -> tuple[PauliProp, ...]:
         if pauli_type == "X":
             if input_idx == 0:
                 return (
-                    (True, False),
-                    (False, True),
+                    PauliProp(True, False),
+                    PauliProp(False, True),
                 )
             else:
                 return (
-                    (False, True),
-                    (True, False),
+                    PauliProp(False, True),
+                    PauliProp(True, False),
                 )
         else:
             if input_idx == 0:
-                return ((False, True), (False, False))
+                return (PauliProp(False, True), PauliProp(False, False))
             else:
                 return (
-                    (False, False),
-                    (False, True),
+                    PauliProp(False, False),
+                    PauliProp(False, True),
                 )
 
 

--- a/inconspiquous/gates/core.py
+++ b/inconspiquous/gates/core.py
@@ -76,7 +76,6 @@ class CliffordGateAttr(GateAttr, ABC):
             - X propagates to Z: pauli_prop(0, "X") returns ((x: False, z: True),)
             - Z propagates to X: pauli_prop(0, "Z") returns ((x: True, z: False),)
         """
-        ...
 
 
 class SingleQubitCliffordGate(CliffordGateAttr):

--- a/inconspiquous/gates/core.py
+++ b/inconspiquous/gates/core.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Literal
+from typing import Literal, NamedTuple
 
 from xdsl.ir import (
     ParametrizedAttribute,
@@ -43,6 +43,15 @@ class TwoQubitGate(GateAttr):
         return 2
 
 
+class PauliProp(NamedTuple):
+    """
+    Describes the combination of x and z pauli gates.
+    """
+
+    x: bool
+    z: bool
+
+
 class CliffordGateAttr(GateAttr, ABC):
     """
     Base class for Clifford gates that support Pauli propagation.
@@ -51,7 +60,7 @@ class CliffordGateAttr(GateAttr, ABC):
     @abstractmethod
     def pauli_prop(
         self, input_idx: int, pauli_type: Literal["X", "Z"]
-    ) -> tuple[tuple[bool, bool], ...]:
+    ) -> tuple[PauliProp, ...]:
         """
         Compute Pauli propagation through this gate.
 
@@ -60,14 +69,14 @@ class CliffordGateAttr(GateAttr, ABC):
             pauli_type: Either "X" or "Z" indicating the type of Pauli gate
 
         Returns:
-            A tuple of (X, Z) pairs for each output qubit, where True indicates
-            that the corresponding Pauli component should be applied to that output.
+            A PauliProp object where the `x` and `z` component determine whether
+            the corresponding Pauli component should be applied to that output.
 
         For example, for Hadamard gate:
-            - X propagates to Z: pauli_prop(0, "X") returns ((False, True),)
-            - Z propagates to X: pauli_prop(0, "Z") returns ((True, False),)
+            - X propagates to Z: pauli_prop(0, "X") returns ((x: False, z: True),)
+            - Z propagates to X: pauli_prop(0, "Z") returns ((x: True, z: False),)
         """
-        pass
+        ...
 
 
 class SingleQubitCliffordGate(CliffordGateAttr):

--- a/inconspiquous/transforms/xzs/commute.py
+++ b/inconspiquous/transforms/xzs/commute.py
@@ -95,22 +95,20 @@ class XZCommutePattern(RewritePattern):
             false_const_needed = False
             new_outputs: list[SSAValue] = []
 
-            for out_idx, ((x_from_x, z_from_x), (x_from_z, z_from_z)) in enumerate(
-                zip(x_prop, z_prop)
-            ):
+            for out_idx, (from_x, from_z) in enumerate(zip(x_prop, z_prop)):
                 apply_x: SSAValue
                 apply_z: SSAValue
                 needs_gate = False
 
-                if x_from_x and x_from_z:
+                if from_x.x and from_z.x:
                     xor_x = arith.XOrIOp(gate.x, gate.z)
                     apply_x = xor_x.result
                     ops_to_insert.append(xor_x)
                     needs_gate = True
-                elif x_from_x:
+                elif from_x.x:
                     apply_x = gate.x
                     needs_gate = True
-                elif x_from_z:
+                elif from_z.x:
                     apply_x = gate.z
                     needs_gate = True
                 else:
@@ -118,15 +116,15 @@ class XZCommutePattern(RewritePattern):
                     false_const_needed = True
 
                 # Z component
-                if z_from_x and z_from_z:
+                if from_x.z and from_z.z:
                     xor_z = arith.XOrIOp(gate.x, gate.z)
                     apply_z = xor_z.result
                     ops_to_insert.append(xor_z)
                     needs_gate = True
-                elif z_from_x:
+                elif from_x.z:
                     apply_z = gate.x
                     needs_gate = True
-                elif z_from_z:
+                elif from_z.z:
                     apply_z = gate.z
                     needs_gate = True
                 else:


### PR DESCRIPTION
Switch from tuple[bool,bool] to a named tuple, it was an oversight in the issue description to suggest the tuple where the named tuple is more informative and should be no/little performance hit.

@superlopuh does this look reasonable or is there a better way to use these things?