### PR TITLE
misc: cleanup

### DIFF
--- a/inconspiquous/dialects/gate.py
+++ b/inconspiquous/dialects/gate.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 from typing import ClassVar, Literal
 
 from xdsl.dialects.builtin import (
-    IndexType,
-    IntegerAttr,
+    IntAttr,
     AnyFloatConstr,
     i1,
     IntegerType,
@@ -32,7 +31,6 @@ from xdsl.irdl import (
     prop_def,
     result_def,
     traits_def,
-    eq,
 )
 from xdsl.parser import AttrParser
 from xdsl.pattern_rewriter import RewritePattern
@@ -59,22 +57,22 @@ class GateType(ParametrizedAttribute, TypeAttribute):
 
     name = "gate.type"
 
-    num_qubits: ParameterDef[IntegerAttr[IndexType]]
+    num_qubits: ParameterDef[IntAttr]
 
-    def __init__(self, num_qubits: int | IntegerAttr[IndexType]):
+    def __init__(self, num_qubits: int | IntAttr):
         if isinstance(num_qubits, int):
-            num_qubits = IntegerAttr.from_index_int_value(num_qubits)
+            num_qubits = IntAttr(num_qubits)
         super().__init__(num_qubits)
 
     @classmethod
-    def parse_parameters(cls, parser: AttrParser) -> tuple[IntegerAttr[IndexType]]:
+    def parse_parameters(cls, parser: AttrParser) -> tuple[IntAttr]:
         with parser.in_angle_brackets():
             i = parser.parse_integer(allow_boolean=False, allow_negative=False)
-            return (IntegerAttr.from_index_int_value(i),)
+            return (IntAttr(i),)
 
     def print_parameters(self, printer: Printer) -> None:
         with printer.in_angle_brackets():
-            printer.print_string(str(self.num_qubits.value.data))
+            printer.print_int(self.num_qubits.data)
 
     @classmethod
     def constr(
@@ -84,11 +82,7 @@ class GateType(ParametrizedAttribute, TypeAttribute):
             return BaseAttr(GateType)
         return ParamAttrConstraint(
             GateType,
-            (
-                IntegerAttr.constr(
-                    value=IntAttrConstraint(int_constraint), type=eq(IndexType())
-                ),
-            ),
+            (IntAttrConstraint(int_constraint),),
         )
 
 

--- a/inconspiquous/dialects/measurement.py
+++ b/inconspiquous/dialects/measurement.py
@@ -12,7 +12,6 @@ from xdsl.irdl import (
     ParamAttrConstraint,
     ParameterDef,
     irdl_attr_definition,
-    eq,
     irdl_op_definition,
     operand_def,
     prop_def,
@@ -23,7 +22,7 @@ from xdsl.parser import AttrParser
 from xdsl.pattern_rewriter import RewritePattern
 from xdsl.printer import Printer
 from inconspiquous.measurement import MeasurementAttr
-from xdsl.dialects.builtin import IndexType, IntAttrConstraint, IntegerAttr
+from xdsl.dialects.builtin import IntAttr, IntAttrConstraint
 from xdsl.traits import ConstantLike, HasCanonicalizationPatternsTrait, Pure
 from inconspiquous.constraints import SizedAttributeConstraint
 from inconspiquous.dialects.angle import AngleAttr, AngleType
@@ -78,22 +77,22 @@ class MeasurementType(ParametrizedAttribute, TypeAttribute):
 
     name = "measurement.type"
 
-    num_qubits: ParameterDef[IntegerAttr[IndexType]]
+    num_qubits: ParameterDef[IntAttr]
 
-    def __init__(self, num_qubits: int | IntegerAttr[IndexType]):
+    def __init__(self, num_qubits: int | IntAttr):
         if isinstance(num_qubits, int):
-            num_qubits = IntegerAttr.from_index_int_value(num_qubits)
+            num_qubits = IntAttr(num_qubits)
         super().__init__(num_qubits)
 
     @classmethod
-    def parse_parameters(cls, parser: AttrParser) -> tuple[IntegerAttr[IndexType]]:
+    def parse_parameters(cls, parser: AttrParser) -> tuple[IntAttr]:
         with parser.in_angle_brackets():
             i = parser.parse_integer(allow_boolean=False, allow_negative=False)
-            return (IntegerAttr.from_index_int_value(i),)
+            return (IntAttr(i),)
 
     def print_parameters(self, printer: Printer) -> None:
         with printer.in_angle_brackets():
-            printer.print_string(str(self.num_qubits.value.data))
+            printer.print_int(self.num_qubits.data)
 
     @classmethod
     def constr(
@@ -103,11 +102,7 @@ class MeasurementType(ParametrizedAttribute, TypeAttribute):
             return BaseAttr(MeasurementType)
         return ParamAttrConstraint(
             MeasurementType,
-            (
-                IntegerAttr.constr(
-                    value=IntAttrConstraint(int_constraint), type=eq(IndexType())
-                ),
-            ),
+            (IntAttrConstraint(int_constraint),),
         )
 
 

--- a/inconspiquous/gates/core.py
+++ b/inconspiquous/gates/core.py
@@ -78,12 +78,8 @@ class CliffordGateAttr(GateAttr, ABC):
         """
 
 
-class SingleQubitCliffordGate(CliffordGateAttr):
+class SingleQubitCliffordGate(CliffordGateAttr, SingleQubitGate):
     """Base class for single-qubit Clifford gates."""
-
-    @property
-    def num_qubits(self) -> int:
-        return 1
 
 
 class PauliGate(SingleQubitCliffordGate):
@@ -99,9 +95,5 @@ class PauliGate(SingleQubitCliffordGate):
             return (PauliProp(False, True),)
 
 
-class TwoQubitCliffordGate(CliffordGateAttr):
+class TwoQubitCliffordGate(CliffordGateAttr, TwoQubitGate):
     """Base class for two-qubit Clifford gates."""
-
-    @property
-    def num_qubits(self) -> int:
-        return 2

--- a/tests/filecheck/dialects/prob/canonicalize.mlir
+++ b/tests/filecheck/dialects/prob/canonicalize.mlir
@@ -17,13 +17,13 @@
 
 // CHECK: %[[#first:]], %[[#second:]], %[[#third:]] = "test.op"() : () -> (i32, i32, i32)
 %4, %5, %6 = "test.op"() : () -> (i32, i32, i32)
-// CHECK-NEXT: %{{.*}} = prob.fin_supp [ 0.375 of %[[#first]], else %[[#second]] ] : i32
+// CHECK-NEXT: %{{.*}} = prob.fin_supp [ 3.750000e-01 of %[[#first]], else %[[#second]] ] : i32
 %7 = prob.fin_supp [ 0.125 of %4, 0.25 of %4, else %5 ] : i32
 
-// CHECK-NEXT: %{{.*}} = prob.fin_supp [ 0.1 of %[[#first]], else %[[#third]] ] : i32
+// CHECK-NEXT: %{{.*}} = prob.fin_supp [ 1.000000e-01 of %[[#first]], else %[[#third]] ] : i32
 %8 = prob.fin_supp [ 0.1 of %4, 0.0 of %5, else %6 ] : i32
 
-// CHECK-NEXT: %{{.*}} = prob.fin_supp [ 0.2 of %[[#second]], else %[[#first]] ] : i32
+// CHECK-NEXT: %{{.*}} = prob.fin_supp [ 2.000000e-01 of %[[#second]], else %[[#first]] ] : i32
 %9 = prob.fin_supp [ 0.1 of %4, 0.2 of %5, else %4 ] : i32
 
 "test.op"(%7, %8, %9) : (i32, i32, i32) -> ()

--- a/tests/filecheck/dialects/prob/ops.mlir
+++ b/tests/filecheck/dialects/prob/ops.mlir
@@ -11,7 +11,7 @@
 
 %2, %3, %4 = "test.op"() : () -> (i64, i64, i64)
 
-// CHECK: %{{.*}} = prob.fin_supp [ 0.1 of %{{.*}}, 0.2 of %{{.*}}, else %{{.*}} ] : i64
+// CHECK: %{{.*}} = prob.fin_supp [ 1.000000e-01 of %{{.*}}, 2.000000e-01 of %{{.*}}, else %{{.*}} ] : i64
 %5 = prob.fin_supp [
   0.1 of %2,
   0.2 of %3,

--- a/tests/filecheck/transforms/lower_to_fin_supp.mlir
+++ b/tests/filecheck/transforms/lower_to_fin_supp.mlir
@@ -2,19 +2,19 @@
 
 // CHECK:    %0 = arith.constant false
 // CHECK-NEXT:    %1 = arith.constant true
-// CHECK-NEXT:    %2 = prob.fin_supp [ 0.1 of %1, else %0 ] : i1
+// CHECK-NEXT:    %2 = prob.fin_supp [ 1.000000e-01 of %1, else %0 ] : i1
 %0 = prob.bernoulli 0.1
 
 // CHECK-NEXT:    %3 = arith.constant true
 // CHECK-NEXT:    %4 = arith.constant false
-// CHECK-NEXT:    %5 = prob.fin_supp [ 0.5 of %3, else %4 ] : i1
+// CHECK-NEXT:    %5 = prob.fin_supp [ 5.000000e-01 of %3, else %4 ] : i1
 %1 = prob.uniform : i1
 
 // CHECK-NEXT:    %6 = arith.constant 1 : i2
 // CHECK-NEXT:    %7 = arith.constant -2 : i2
 // CHECK-NEXT:    %8 = arith.constant -1 : i2
 // CHECK-NEXT:    %9 = arith.constant 0 : i2
-// CHECK-NEXT:    %10 = prob.fin_supp [ 0.25 of %6, 0.25 of %7, 0.25 of %8, else %9 ] : i2
+// CHECK-NEXT:    %10 = prob.fin_supp [ 2.500000e-01 of %6, 2.500000e-01 of %7, 2.500000e-01 of %8, else %9 ] : i2
 %2 = prob.uniform : i2
 
 // CHECK-NEXT:    %11 = prob.uniform : i3


### PR DESCRIPTION
Various miscellaneous improvements/cleanups.
In particular there was no reason to use IntegerAttr for the parameters of some of the types.