### PR TITLE
misc: update locks and deal with deprecations

### DIFF
--- a/inconspiquous/constraints.py
+++ b/inconspiquous/constraints.py
@@ -5,7 +5,6 @@ from xdsl.ir import Attribute, VerifyException
 from xdsl.irdl import (
     AttrConstraint,
     ConstraintContext,
-    GenericAttrConstraint,
     IntConstraint,
 )
 
@@ -21,7 +20,7 @@ SizedAttributeT = TypeVar("SizedAttributeT", bound=SizedAttribute)
 
 
 @dataclass(frozen=True)
-class SizedAttributeConstraint(GenericAttrConstraint[SizedAttributeCovT]):
+class SizedAttributeConstraint(AttrConstraint[SizedAttributeCovT]):
     """
     Constraints an attribute to be a gate type with size given by an integer constraint.
     """
@@ -41,5 +40,5 @@ class SizedAttributeConstraint(GenericAttrConstraint[SizedAttributeCovT]):
 
     def mapping_type_vars(
         self, type_var_mapping: dict[TypeVar, AttrConstraint]
-    ) -> GenericAttrConstraint[SizedAttributeCovT]:
+    ) -> AttrConstraint[SizedAttributeCovT]:
         return self

--- a/inconspiquous/dialects/gate.py
+++ b/inconspiquous/dialects/gate.py
@@ -17,7 +17,7 @@ from xdsl.ir import (
 from xdsl.irdl import (
     AnyInt,
     BaseAttr,
-    GenericAttrConstraint,
+    AttrConstraint,
     IRDLOperation,
     IntConstraint,
     IntVarConstraint,
@@ -76,7 +76,7 @@ class GateType(ParametrizedAttribute, TypeAttribute):
     @classmethod
     def constr(
         cls, int_constraint: IntConstraint | None = None
-    ) -> GenericAttrConstraint[GateType]:
+    ) -> AttrConstraint[GateType]:
         if int_constraint is None:
             return BaseAttr(GateType)
         return ParamAttrConstraint(

--- a/inconspiquous/dialects/measurement.py
+++ b/inconspiquous/dialects/measurement.py
@@ -5,7 +5,7 @@ from xdsl.ir import Dialect, Operation, ParametrizedAttribute, SSAValue, TypeAtt
 from xdsl.irdl import (
     AnyInt,
     BaseAttr,
-    GenericAttrConstraint,
+    AttrConstraint,
     IRDLOperation,
     IntConstraint,
     IntVarConstraint,
@@ -96,7 +96,7 @@ class MeasurementType(ParametrizedAttribute, TypeAttribute):
     @classmethod
     def constr(
         cls, int_constraint: IntConstraint | None = None
-    ) -> GenericAttrConstraint[MeasurementType]:
+    ) -> AttrConstraint[MeasurementType]:
         if int_constraint is None:
             return BaseAttr(MeasurementType)
         return ParamAttrConstraint(

--- a/inconspiquous/dialects/qref.py
+++ b/inconspiquous/dialects/qref.py
@@ -36,7 +36,7 @@ class GateOp(IRDLOperation):
 
     gate = prop_def(SizedAttributeConstraint(GateAttr, _I))
 
-    ins = var_operand_def(RangeOf(eq(BitType()), length=_I))
+    ins = var_operand_def(RangeOf(eq(BitType())).of_length(_I))
 
     assembly_format = "`<` $gate `>` $ins attr-dict"
 
@@ -65,7 +65,7 @@ class DynGateOp(IRDLOperation):
 
     gate = operand_def(GateType.constr(_I))
 
-    ins = var_operand_def(RangeOf(eq(BitType()), length=_I))
+    ins = var_operand_def(RangeOf(eq(BitType())).of_length(_I))
 
     assembly_format = "`<` $gate `>` $ins attr-dict"
 
@@ -88,9 +88,9 @@ class MeasureOp(IRDLOperation):
         default_value=CompBasisMeasurementAttr(),
     )
 
-    in_qubits = var_operand_def(RangeOf(eq(BitType()), length=_I))
+    in_qubits = var_operand_def(RangeOf(eq(BitType())).of_length(_I))
 
-    outs = var_result_def(RangeOf(eq(i1), length=_I))
+    outs = var_result_def(RangeOf(eq(i1)).of_length(_I))
 
     assembly_format = "(`` `<` $measurement^ `>`)? $in_qubits attr-dict"
 
@@ -126,9 +126,9 @@ class DynMeasureOp(IRDLOperation):
 
     measurement = operand_def(MeasurementType.constr(_I))
 
-    in_qubits = var_operand_def(RangeOf(eq(BitType()), length=_I))
+    in_qubits = var_operand_def(RangeOf(eq(BitType())).of_length(_I))
 
-    outs = var_result_def(RangeOf(eq(i1), length=_I))
+    outs = var_result_def(RangeOf(eq(i1)).of_length(_I))
 
     assembly_format = "`<` $measurement `>` $in_qubits attr-dict"
 
@@ -149,7 +149,7 @@ class CircuitOp(IRDLOperation):
 
     _I: ClassVar = IntVarConstraint("I", AnyInt())
 
-    body = region_def("single_block", entry_args=RangeOf(eq(BitType()), length=_I))
+    body = region_def("single_block", entry_args=RangeOf(eq(BitType())).of_length(_I))
     result = result_def(GateType.constr(_I))
 
     assembly_format = "`(` `)` `(` $body `)` `:` `(` `)` `->` type($result) attr-dict"

--- a/inconspiquous/dialects/qssa.py
+++ b/inconspiquous/dialects/qssa.py
@@ -44,9 +44,9 @@ class GateOp(IRDLOperation):
 
     gate = prop_def(SizedAttributeConstraint(GateAttr, _I))
 
-    ins = var_operand_def(RangeOf(eq(BitType()), length=_I))
+    ins = var_operand_def(RangeOf(eq(BitType())).of_length(_I))
 
-    outs = var_result_def(RangeOf(eq(BitType()), length=_I))
+    outs = var_result_def(RangeOf(eq(BitType())).of_length(_I))
 
     assembly_format = "`<` $gate `>` $ins attr-dict"
 
@@ -81,9 +81,9 @@ class DynGateOp(IRDLOperation):
 
     gate = operand_def(GateType.constr(_I))
 
-    ins = var_operand_def(RangeOf(eq(BitType()), length=_I))
+    ins = var_operand_def(RangeOf(eq(BitType())).of_length(_I))
 
-    outs = var_result_def(RangeOf(eq(BitType()), length=_I))
+    outs = var_result_def(RangeOf(eq(BitType())).of_length(_I))
 
     assembly_format = "`<` $gate `>` $ins attr-dict"
 
@@ -107,9 +107,9 @@ class MeasureOp(IRDLOperation):
         default_value=CompBasisMeasurementAttr(),
     )
 
-    in_qubits = var_operand_def(RangeOf(eq(BitType()), length=_I))
+    in_qubits = var_operand_def(RangeOf(eq(BitType())).of_length(_I))
 
-    outs = var_result_def(RangeOf(eq(i1), length=_I))
+    outs = var_result_def(RangeOf(eq(i1)).of_length(_I))
 
     assembly_format = "(`` `<` $measurement^ `>`)? $in_qubits attr-dict"
 
@@ -145,9 +145,9 @@ class DynMeasureOp(IRDLOperation):
 
     measurement = operand_def(MeasurementType.constr(_I))
 
-    in_qubits = var_operand_def(RangeOf(eq(BitType()), length=_I))
+    in_qubits = var_operand_def(RangeOf(eq(BitType())).of_length(_I))
 
-    outs = var_result_def(RangeOf(eq(i1), length=_I))
+    outs = var_result_def(RangeOf(eq(i1)).of_length(_I))
 
     assembly_format = "`<` $measurement `>` $in_qubits attr-dict"
 
@@ -170,7 +170,7 @@ class CircuitOp(IRDLOperation):
 
     _I: ClassVar = IntVarConstraint("I", AnyInt())
 
-    body = region_def("single_block", entry_args=RangeOf(eq(BitType()), length=_I))
+    body = region_def("single_block", entry_args=RangeOf(eq(BitType())).of_length(_I))
     result = result_def(GateType.constr(_I))
 
     assembly_format = "`(` `)` `(` $body `)` `:` `(` `)` `->` type($result) attr-dict"

--- a/inconspiquous/dialects/qu.py
+++ b/inconspiquous/dialects/qu.py
@@ -97,7 +97,7 @@ class AllocOp(IRDLOperation):
         SizedAttributeConstraint(AllocAttr, _I), default_value=AllocZeroAttr()
     )
 
-    outs = var_result_def(RangeOf(eq(BitType()), length=_I))
+    outs = var_result_def(RangeOf(eq(BitType())).of_length(_I))
 
     assembly_format = "(`` `<` $alloc^ `>`)? attr-dict"
 
@@ -116,7 +116,7 @@ class FromBitsOp(IRDLOperation):
 
     name = "qu.from_bits"
     _I: ClassVar = IntVarConstraint("I", AnyInt())
-    qubits = var_operand_def(RangeOf(eq(BitType()), length=_I))
+    qubits = var_operand_def(RangeOf(eq(BitType())).of_length(_I))
     reg = result_def(RegisterType.constr(_I))
 
     assembly_format = "$qubits attr-dict `:` type($reg)"
@@ -134,7 +134,7 @@ class ToBitsOp(IRDLOperation):
     name = "qu.to_bits"
     _I: ClassVar = IntVarConstraint("I", AnyInt())
     reg = operand_def(RegisterType.constr(_I))
-    qubits = var_result_def(RangeOf(eq(BitType()), length=_I))
+    qubits = var_result_def(RangeOf(eq(BitType())).of_length(_I))
 
     assembly_format = "$reg attr-dict `:` type($reg)"
 

--- a/uv.lock
+++ b/uv.lock
@@ -22,11 +22,11 @@ wheels = [
 
 [[package]]
 name = "distlib"
-version = "0.3.9"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/dd/1bec4c5ddb504ca60fc29472f3d27e8d4da1257a854e1d96742f15c1d02d/distlib-0.3.9.tar.gz", hash = "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403", size = 613923, upload-time = "2024-10-09T18:35:47.551Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/a1/cf2472db20f7ce4a6be1253a81cfdf85ad9c7885ffbed7047fb72c24cf87/distlib-0.3.9-py2.py3-none-any.whl", hash = "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87", size = 468973, upload-time = "2024-10-09T18:35:44.272Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
 ]
 
 [[package]]
@@ -399,27 +399,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.12.3"
+version = "0.12.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/2a/43955b530c49684d3c38fcda18c43caf91e99204c2a065552528e0552d4f/ruff-0.12.3.tar.gz", hash = "sha256:f1b5a4b6668fd7b7ea3697d8d98857390b40c1320a63a178eee6be0899ea2d77", size = 4459341, upload-time = "2025-07-11T13:21:16.086Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/ce/8d7dbedede481245b489b769d27e2934730791a9a82765cb94566c6e6abd/ruff-0.12.4.tar.gz", hash = "sha256:13efa16df6c6eeb7d0f091abae50f58e9522f3843edb40d56ad52a5a4a4b6873", size = 5131435, upload-time = "2025-07-17T17:27:19.138Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/fd/b44c5115539de0d598d75232a1cc7201430b6891808df111b8b0506aae43/ruff-0.12.3-py3-none-linux_armv6l.whl", hash = "sha256:47552138f7206454eaf0c4fe827e546e9ddac62c2a3d2585ca54d29a890137a2", size = 10430499, upload-time = "2025-07-11T13:20:26.321Z" },
-    { url = "https://files.pythonhosted.org/packages/43/c5/9eba4f337970d7f639a37077be067e4ec80a2ad359e4cc6c5b56805cbc66/ruff-0.12.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0a9153b000c6fe169bb307f5bd1b691221c4286c133407b8827c406a55282041", size = 11213413, upload-time = "2025-07-11T13:20:30.017Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/2c/fac3016236cf1fe0bdc8e5de4f24c76ce53c6dd9b5f350d902549b7719b2/ruff-0.12.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fa6b24600cf3b750e48ddb6057e901dd5b9aa426e316addb2a1af185a7509882", size = 10586941, upload-time = "2025-07-11T13:20:33.046Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/0f/41fec224e9dfa49a139f0b402ad6f5d53696ba1800e0f77b279d55210ca9/ruff-0.12.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e2506961bf6ead54887ba3562604d69cb430f59b42133d36976421bc8bd45901", size = 10783001, upload-time = "2025-07-11T13:20:35.534Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/ca/dd64a9ce56d9ed6cad109606ac014860b1c217c883e93bf61536400ba107/ruff-0.12.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c4faaff1f90cea9d3033cbbcdf1acf5d7fb11d8180758feb31337391691f3df0", size = 10269641, upload-time = "2025-07-11T13:20:38.459Z" },
-    { url = "https://files.pythonhosted.org/packages/63/5c/2be545034c6bd5ce5bb740ced3e7014d7916f4c445974be11d2a406d5088/ruff-0.12.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40dced4a79d7c264389de1c59467d5d5cefd79e7e06d1dfa2c75497b5269a5a6", size = 11875059, upload-time = "2025-07-11T13:20:41.517Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/d4/a74ef1e801ceb5855e9527dae105eaff136afcb9cc4d2056d44feb0e4792/ruff-0.12.3-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:0262d50ba2767ed0fe212aa7e62112a1dcbfd46b858c5bf7bbd11f326998bafc", size = 12658890, upload-time = "2025-07-11T13:20:44.442Z" },
-    { url = "https://files.pythonhosted.org/packages/13/c8/1057916416de02e6d7c9bcd550868a49b72df94e3cca0aeb77457dcd9644/ruff-0.12.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12371aec33e1a3758597c5c631bae9a5286f3c963bdfb4d17acdd2d395406687", size = 12232008, upload-time = "2025-07-11T13:20:47.374Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/59/4f7c130cc25220392051fadfe15f63ed70001487eca21d1796db46cbcc04/ruff-0.12.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:560f13b6baa49785665276c963edc363f8ad4b4fc910a883e2625bdb14a83a9e", size = 11499096, upload-time = "2025-07-11T13:20:50.348Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/01/a0ad24a5d2ed6be03a312e30d32d4e3904bfdbc1cdbe63c47be9d0e82c79/ruff-0.12.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:023040a3499f6f974ae9091bcdd0385dd9e9eb4942f231c23c57708147b06311", size = 11688307, upload-time = "2025-07-11T13:20:52.945Z" },
-    { url = "https://files.pythonhosted.org/packages/93/72/08f9e826085b1f57c9a0226e48acb27643ff19b61516a34c6cab9d6ff3fa/ruff-0.12.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:883d844967bffff5ab28bba1a4d246c1a1b2933f48cb9840f3fdc5111c603b07", size = 10661020, upload-time = "2025-07-11T13:20:55.799Z" },
-    { url = "https://files.pythonhosted.org/packages/80/a0/68da1250d12893466c78e54b4a0ff381370a33d848804bb51279367fc688/ruff-0.12.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:2120d3aa855ff385e0e562fdee14d564c9675edbe41625c87eeab744a7830d12", size = 10246300, upload-time = "2025-07-11T13:20:58.222Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/22/5f0093d556403e04b6fd0984fc0fb32fbb6f6ce116828fd54306a946f444/ruff-0.12.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6b16647cbb470eaf4750d27dddc6ebf7758b918887b56d39e9c22cce2049082b", size = 11263119, upload-time = "2025-07-11T13:21:01.503Z" },
-    { url = "https://files.pythonhosted.org/packages/92/c9/f4c0b69bdaffb9968ba40dd5fa7df354ae0c73d01f988601d8fac0c639b1/ruff-0.12.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e1417051edb436230023575b149e8ff843a324557fe0a265863b7602df86722f", size = 11746990, upload-time = "2025-07-11T13:21:04.524Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/84/7cc7bd73924ee6be4724be0db5414a4a2ed82d06b30827342315a1be9e9c/ruff-0.12.3-py3-none-win32.whl", hash = "sha256:dfd45e6e926deb6409d0616078a666ebce93e55e07f0fb0228d4b2608b2c248d", size = 10589263, upload-time = "2025-07-11T13:21:07.148Z" },
-    { url = "https://files.pythonhosted.org/packages/07/87/c070f5f027bd81f3efee7d14cb4d84067ecf67a3a8efb43aadfc72aa79a6/ruff-0.12.3-py3-none-win_amd64.whl", hash = "sha256:a946cf1e7ba3209bdef039eb97647f1c77f6f540e5845ec9c114d3af8df873e7", size = 11695072, upload-time = "2025-07-11T13:21:11.004Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/30/f3eaf6563c637b6e66238ed6535f6775480db973c836336e4122161986fc/ruff-0.12.3-py3-none-win_arm64.whl", hash = "sha256:5f9c7c9c8f84c2d7f27e93674d27136fbf489720251544c4da7fb3d742e011b1", size = 10805855, upload-time = "2025-07-11T13:21:13.547Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/9f/517bc5f61bad205b7f36684ffa5415c013862dee02f55f38a217bdbe7aa4/ruff-0.12.4-py3-none-linux_armv6l.whl", hash = "sha256:cb0d261dac457ab939aeb247e804125a5d521b21adf27e721895b0d3f83a0d0a", size = 10188824, upload-time = "2025-07-17T17:26:31.412Z" },
+    { url = "https://files.pythonhosted.org/packages/28/83/691baae5a11fbbde91df01c565c650fd17b0eabed259e8b7563de17c6529/ruff-0.12.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:55c0f4ca9769408d9b9bac530c30d3e66490bd2beb2d3dae3e4128a1f05c7442", size = 10884521, upload-time = "2025-07-17T17:26:35.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/8d/756d780ff4076e6dd035d058fa220345f8c458391f7edfb1c10731eedc75/ruff-0.12.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a8224cc3722c9ad9044da7f89c4c1ec452aef2cfe3904365025dd2f51daeae0e", size = 10277653, upload-time = "2025-07-17T17:26:37.897Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/97/8eeee0f48ece153206dce730fc9e0e0ca54fd7f261bb3d99c0a4343a1892/ruff-0.12.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9949d01d64fa3672449a51ddb5d7548b33e130240ad418884ee6efa7a229586", size = 10485993, upload-time = "2025-07-17T17:26:40.68Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b8/22a43d23a1f68df9b88f952616c8508ea6ce4ed4f15353b8168c48b2d7e7/ruff-0.12.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:be0593c69df9ad1465e8a2d10e3defd111fdb62dcd5be23ae2c06da77e8fcffb", size = 10022824, upload-time = "2025-07-17T17:26:43.564Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/70/37c234c220366993e8cffcbd6cadbf332bfc848cbd6f45b02bade17e0149/ruff-0.12.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a7dea966bcb55d4ecc4cc3270bccb6f87a337326c9dcd3c07d5b97000dbff41c", size = 11524414, upload-time = "2025-07-17T17:26:46.219Z" },
+    { url = "https://files.pythonhosted.org/packages/14/77/c30f9964f481b5e0e29dd6a1fae1f769ac3fd468eb76fdd5661936edd262/ruff-0.12.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:afcfa3ab5ab5dd0e1c39bf286d829e042a15e966b3726eea79528e2e24d8371a", size = 12419216, upload-time = "2025-07-17T17:26:48.883Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/79/af7fe0a4202dce4ef62c5e33fecbed07f0178f5b4dd9c0d2fcff5ab4a47c/ruff-0.12.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c057ce464b1413c926cdb203a0f858cd52f3e73dcb3270a3318d1630f6395bb3", size = 11976756, upload-time = "2025-07-17T17:26:51.754Z" },
+    { url = "https://files.pythonhosted.org/packages/09/d1/33fb1fc00e20a939c305dbe2f80df7c28ba9193f7a85470b982815a2dc6a/ruff-0.12.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e64b90d1122dc2713330350626b10d60818930819623abbb56535c6466cce045", size = 11020019, upload-time = "2025-07-17T17:26:54.265Z" },
+    { url = "https://files.pythonhosted.org/packages/64/f4/e3cd7f7bda646526f09693e2e02bd83d85fff8a8222c52cf9681c0d30843/ruff-0.12.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2abc48f3d9667fdc74022380b5c745873499ff827393a636f7a59da1515e7c57", size = 11277890, upload-time = "2025-07-17T17:26:56.914Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/d0/69a85fb8b94501ff1a4f95b7591505e8983f38823da6941eb5b6badb1e3a/ruff-0.12.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:2b2449dc0c138d877d629bea151bee8c0ae3b8e9c43f5fcaafcd0c0d0726b184", size = 10348539, upload-time = "2025-07-17T17:26:59.381Z" },
+    { url = "https://files.pythonhosted.org/packages/16/a0/91372d1cb1678f7d42d4893b88c252b01ff1dffcad09ae0c51aa2542275f/ruff-0.12.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:56e45bb11f625db55f9b70477062e6a1a04d53628eda7784dce6e0f55fd549eb", size = 10009579, upload-time = "2025-07-17T17:27:02.462Z" },
+    { url = "https://files.pythonhosted.org/packages/23/1b/c4a833e3114d2cc0f677e58f1df6c3b20f62328dbfa710b87a1636a5e8eb/ruff-0.12.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:478fccdb82ca148a98a9ff43658944f7ab5ec41c3c49d77cd99d44da019371a1", size = 10942982, upload-time = "2025-07-17T17:27:05.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/ce/ce85e445cf0a5dd8842f2f0c6f0018eedb164a92bdf3eda51984ffd4d989/ruff-0.12.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:0fc426bec2e4e5f4c4f182b9d2ce6a75c85ba9bcdbe5c6f2a74fcb8df437df4b", size = 11343331, upload-time = "2025-07-17T17:27:08.652Z" },
+    { url = "https://files.pythonhosted.org/packages/35/cf/441b7fc58368455233cfb5b77206c849b6dfb48b23de532adcc2e50ccc06/ruff-0.12.4-py3-none-win32.whl", hash = "sha256:4de27977827893cdfb1211d42d84bc180fceb7b72471104671c59be37041cf93", size = 10267904, upload-time = "2025-07-17T17:27:11.814Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/7e/20af4a0df5e1299e7368d5ea4350412226afb03d95507faae94c80f00afd/ruff-0.12.4-py3-none-win_amd64.whl", hash = "sha256:fe0b9e9eb23736b453143d72d2ceca5db323963330d5b7859d60d101147d461a", size = 11209038, upload-time = "2025-07-17T17:27:14.417Z" },
+    { url = "https://files.pythonhosted.org/packages/11/02/8857d0dfb8f44ef299a5dfd898f673edefb71e3b533b3b9d2db4c832dd13/ruff-0.12.4-py3-none-win_arm64.whl", hash = "sha256:0618ec4442a83ab545e5b71202a5c0ed7791e8471435b94e655b570a5031a98e", size = 10469336, upload-time = "2025-07-17T17:27:16.913Z" },
 ]
 
 [[package]]
@@ -496,22 +496,22 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "20.31.2"
+version = "20.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
     { name = "filelock" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/56/2c/444f465fb2c65f40c3a104fd0c495184c4f2336d65baf398e3c75d72ea94/virtualenv-20.31.2.tar.gz", hash = "sha256:e10c0a9d02835e592521be48b332b6caee6887f332c111aa79a09b9e79efc2af", size = 6076316, upload-time = "2025-05-08T17:58:23.811Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/96/0834f30fa08dca3738614e6a9d42752b6420ee94e58971d702118f7cfd30/virtualenv-20.32.0.tar.gz", hash = "sha256:886bf75cadfdc964674e6e33eb74d787dff31ca314ceace03ca5810620f4ecf0", size = 6076970, upload-time = "2025-07-21T04:09:50.985Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/40/b1c265d4b2b62b58576588510fc4d1fe60a86319c8de99fd8e9fec617d2c/virtualenv-20.31.2-py3-none-any.whl", hash = "sha256:36efd0d9650ee985f0cad72065001e66d49a6f24eb44d98980f630686243cf11", size = 6057982, upload-time = "2025-05-08T17:58:21.15Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/c6/f8f28009920a736d0df434b52e9feebfb4d702ba942f15338cb4a83eafc1/virtualenv-20.32.0-py3-none-any.whl", hash = "sha256:2c310aecb62e5aa1b06103ed7c2977b81e042695de2697d01017ff0f1034af56", size = 6057761, upload-time = "2025-07-21T04:09:48.059Z" },
 ]
 
 [[package]]
 name = "xdsl"
-version = "0.45.1.dev44+gd557e319"
-source = { git = "https://github.com/xdslproject/xdsl#d557e319bb5ca609fc2d634742b46125a257a56c" }
+version = "0.46.1.dev1+g18f494ad"
+source = { git = "https://github.com/xdslproject/xdsl#18f494ad1d2ed9f96000ece06cc504faafbf5e3a" }
 dependencies = [
     { name = "immutabledict" },
     { name = "ordered-set" },


### PR DESCRIPTION
lengths on range constraints got deprecated in xDSL and `GenericAttrConstraint` got renamed to `AttrConstraint`