### PR TITLE
dialects: (qu) add qubit release

### DIFF
--- a/inconspiquous/dialects/qu.py
+++ b/inconspiquous/dialects/qu.py
@@ -3,6 +3,7 @@ from typing import ClassVar
 from xdsl.dialects.builtin import IntAttr, IntAttrConstraint
 from xdsl.ir import (
     Dialect,
+    Operation,
     ParametrizedAttribute,
     TypeAttribute,
     SSAValue,
@@ -111,6 +112,18 @@ class AllocOp(IRDLOperation):
 
 
 @irdl_op_definition
+class ReleaseOp(IRDLOperation):
+    name = "qu.release"
+
+    in_qubit = operand_def(BitType)
+
+    assembly_format = "$in_qubit attr-dict"
+
+    def __init__(self, in_qubit: Operation | SSAValue):
+        super().__init__(operands=(in_qubit,))
+
+
+@irdl_op_definition
 class FromBitsOp(IRDLOperation):
     """Converts a collection of input qubits to a register."""
 
@@ -209,6 +222,18 @@ class SplitOp(IRDLOperation):
 
 Qu = Dialect(
     "qu",
-    [AllocOp, FromBitsOp, ToBitsOp, CombineOp, SplitOp],
-    [BitType, RegisterType, AllocZeroAttr, AllocPlusAttr],
+    [
+        AllocOp,
+        ReleaseOp,
+        FromBitsOp,
+        ToBitsOp,
+        CombineOp,
+        SplitOp,
+    ],
+    [
+        BitType,
+        RegisterType,
+        AllocZeroAttr,
+        AllocPlusAttr,
+    ],
 )

--- a/tests/filecheck/dialects/qu.mlir
+++ b/tests/filecheck/dialects/qu.mlir
@@ -1,8 +1,6 @@
 // RUN: QUOPT_ROUNDTRIP
 // RUN: QUOPT_GENERIC_ROUNDTRIP
 
-//--- Qubit Allocation Tests ---//
-
 // CHECK-LABEL: func.func @test_qubit_allocs() {
 // CHECK-NEXT:    %q = qu.alloc
 // CHECK-NEXT:    %q2 = qu.alloc<#qu.plus>
@@ -20,9 +18,21 @@ func.func @test_qubit_allocs() {
   func.return
 }
 
-//---
-
-//--- Qubit Register Tests ---//
+// CHECK-LABEL: @test_qubit_release
+// CHECK-NEXT:    %q = qu.alloc
+// CHECK-NEXT:    qu.release %q
+// CHECK-NEXT:    func.return
+// CHECK-NEXT:  }
+// CHECK-GENERIC-LABEL: "test_qubit_release"
+// CHECK-GENERIC-NEXT:    %q = "qu.alloc"() <{alloc = #qu.zero}> : () -> !qu.bit
+// CHECK-GENERIC-NEXT:    "qu.release"(%q) : (!qu.bit) -> ()
+// CHECK-GENERIC-NEXT:    "func.return"() : () -> ()
+// CHECK-GENERIC-NEXT:  }) : () -> ()
+func.func @test_qubit_release() {
+  %q = qu.alloc
+  qu.release %q
+  func.return
+}
 
 // CHECK-LABEL: func.func @test_qreg_ops() {
 // CHECK-NEXT:    %q0 = qu.alloc


### PR DESCRIPTION
Add explicit qubit release method. Plan is to make measurement no longer release qubits, which will allow better qref/qssa interop