### PR TITLE
dialects: (gate) remove gate.control

### DIFF
--- a/inconspiquous/constraints.py
+++ b/inconspiquous/constraints.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import AbstractSet, Mapping
+from typing import Mapping
 from typing_extensions import TypeVar
 from xdsl.ir import Attribute, VerifyException
 from xdsl.irdl import (
@@ -45,29 +45,3 @@ class SizedAttributeConstraint(AttrConstraint[SizedAttributeCovT]):
         return SizedAttributeConstraint(
             self.base_class, self.size_constraint.mapping_type_vars(type_var_mapping)
         )
-
-
-@dataclass(frozen=True)
-class IncrementConstraint(IntConstraint):
-    """
-    Increments an int constraint by 1
-    """
-
-    constraint: IntConstraint
-
-    def verify(self, i: int, constraint_context: ConstraintContext) -> None:
-        self.constraint.verify(i - 1, constraint_context)
-
-    def variables(self) -> set[str]:
-        return self.constraint.variables()
-
-    def can_infer(self, var_constraint_names: AbstractSet[str]) -> bool:
-        return self.constraint.can_infer(var_constraint_names)
-
-    def infer(self, context: ConstraintContext) -> int:
-        return self.constraint.infer(context) + 1
-
-    def mapping_type_vars(
-        self, type_var_mapping: Mapping[TypeVar, AttrConstraint | IntConstraint]
-    ) -> IntConstraint:
-        return IncrementConstraint(self.constraint.mapping_type_vars(type_var_mapping))

--- a/inconspiquous/dialects/gate.py
+++ b/inconspiquous/dialects/gate.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from abc import ABC
+from abc import ABC, abstractmethod
 from typing import ClassVar, Literal
 
 from xdsl.dialects.builtin import (
@@ -47,7 +47,7 @@ from inconspiquous.gates import (
     TwoQubitCliffordGate,
     SingleQubitGate,
 )
-from inconspiquous.constraints import IncrementConstraint, SizedAttributeConstraint
+from inconspiquous.constraints import SizedAttributeConstraint
 from inconspiquous.gates.core import (
     CliffordGateAttr,
     PauliGate,
@@ -244,6 +244,30 @@ class JGate(RotationGate, SingleQubitGate):
 
 
 @irdl_attr_definition
+class CRXGate(RotationGate, TwoQubitGate):
+    name = "gate.crx"
+
+    def __init__(self, angle: float | AngleAttr):
+        super().__init__(angle)
+
+
+@irdl_attr_definition
+class CRYGate(RotationGate, TwoQubitGate):
+    name = "gate.cry"
+
+    def __init__(self, angle: float | AngleAttr):
+        super().__init__(angle)
+
+
+@irdl_attr_definition
+class CRZGate(RotationGate, TwoQubitGate):
+    name = "gate.crz"
+
+    def __init__(self, angle: float | AngleAttr):
+        super().__init__(angle)
+
+
+@irdl_attr_definition
 class RZZGate(RotationGate, TwoQubitGate):
     name = "gate.rzz"
 
@@ -258,6 +282,18 @@ class DynRotationGate(IRDLOperation, HasCanonicalizationPatternsInterface, ABC):
 
     assembly_format = "`` `<` $angle `>` attr-dict"
 
+    @classmethod
+    @abstractmethod
+    def static_gate(cls) -> type[RotationGate]:
+        """Type of the corresponding static gate attribute"""
+        ...
+
+    @classmethod
+    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
+        from inconspiquous.transforms.canonicalization import gate
+
+        return (gate.DynRotationGateToRotationPattern(cls.static_gate()),)
+
 
 class SingleQubitDynRotationGate(DynRotationGate, ABC):
     out = result_def(GateType(1))
@@ -266,15 +302,20 @@ class SingleQubitDynRotationGate(DynRotationGate, ABC):
         super().__init__(operands=(angle,), result_types=(GateType(1),))
 
 
+class TwoQubitDynRotationGate(DynRotationGate, ABC):
+    out = result_def(GateType(2))
+
+    def __init__(self, angle: SSAValue | Operation):
+        super().__init__(operands=(angle,), result_types=(GateType(2),))
+
+
 @irdl_op_definition
 class DynRXGate(SingleQubitDynRotationGate):
     name = "gate.dyn_rx"
 
     @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
-        from inconspiquous.transforms.canonicalization import gate
-
-        return (gate.DynRotationGateToRotationPattern(RXGate),)
+    def static_gate(cls) -> type[RotationGate]:
+        return RXGate
 
 
 @irdl_op_definition
@@ -282,10 +323,8 @@ class DynRYGate(SingleQubitDynRotationGate):
     name = "gate.dyn_ry"
 
     @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
-        from inconspiquous.transforms.canonicalization import gate
-
-        return (gate.DynRotationGateToRotationPattern(RYGate),)
+    def static_gate(cls) -> type[RotationGate]:
+        return RYGate
 
 
 @irdl_op_definition
@@ -293,26 +332,8 @@ class DynRZGate(SingleQubitDynRotationGate):
     name = "gate.dyn_rz"
 
     @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
-        from inconspiquous.transforms.canonicalization import gate
-
-        return (gate.DynRotationGateToRotationPattern(RZGate),)
-
-
-@irdl_op_definition
-class DynRZZGate(DynRotationGate):
-    name = "gate.dyn_rzz"
-
-    out = result_def(GateType(2))
-
-    def __init__(self, angle: SSAValue | Operation):
-        super().__init__(operands=(angle,), result_types=(GateType(2),))
-
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
-        from inconspiquous.transforms.canonicalization import gate
-
-        return (gate.DynRotationGateToRotationPattern(RZZGate),)
+    def static_gate(cls) -> type[RotationGate]:
+        return RZGate
 
 
 @irdl_op_definition
@@ -320,10 +341,44 @@ class DynJGate(SingleQubitDynRotationGate):
     name = "gate.dyn_j"
 
     @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
-        from inconspiquous.transforms.canonicalization import gate
+    def static_gate(cls) -> type[RotationGate]:
+        return JGate
 
-        return (gate.DynRotationGateToRotationPattern(JGate),)
+
+@irdl_op_definition
+class DynCRXGate(TwoQubitDynRotationGate):
+    name = "gate.dyn_crx"
+
+    @classmethod
+    def static_gate(cls) -> type[RotationGate]:
+        return CRXGate
+
+
+@irdl_op_definition
+class DynCRYGate(TwoQubitDynRotationGate):
+    name = "gate.dyn_cry"
+
+    @classmethod
+    def static_gate(cls) -> type[RotationGate]:
+        return CRYGate
+
+
+@irdl_op_definition
+class DynCRZGate(TwoQubitDynRotationGate):
+    name = "gate.dyn_crz"
+
+    @classmethod
+    def static_gate(cls) -> type[RotationGate]:
+        return CRZGate
+
+
+@irdl_op_definition
+class DynRZZGate(TwoQubitDynRotationGate):
+    name = "gate.dyn_rzz"
+
+    @classmethod
+    def static_gate(cls) -> type[RotationGate]:
+        return RZZGate
 
 
 @irdl_attr_definition
@@ -533,36 +588,6 @@ class XZOp(IRDLOperation):
         super().__init__(operands=(x, z), result_types=(GateType(1),))
 
 
-@irdl_op_definition
-class ControlOp(IRDLOperation, HasCanonicalizationPatternsInterface):
-    """
-    Adds a control qubit to an input gate.
-    """
-
-    name = "gate.control"
-
-    _I: ClassVar = IntVarConstraint("I", AnyInt())
-
-    gate = operand_def(GateType.constr(_I))
-
-    out = result_def(GateType.constr(IncrementConstraint(_I)))
-
-    traits = traits_def(Pure())
-
-    assembly_format = "$gate `:` type($gate) attr-dict"
-
-    def __init__(self, gate: SSAValue[GateType]):
-        super().__init__(
-            operands=(gate,), result_types=(GateType(gate.type.num_qubits.data + 1),)
-        )
-
-    @classmethod
-    def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
-        from inconspiquous.transforms.canonicalization.gate import ControlOpFoldPattern
-
-        return (ControlOpFoldPattern(),)
-
-
 Gate = Dialect(
     "gate",
     [
@@ -575,8 +600,10 @@ Gate = Dialect(
         DynRYGate,
         DynRZGate,
         DynJGate,
+        DynCRXGate,
+        DynCRYGate,
+        DynCRZGate,
         DynRZZGate,
-        ControlOp,
     ],
     [
         HadamardGate,
@@ -591,6 +618,9 @@ Gate = Dialect(
         RYGate,
         RZGate,
         JGate,
+        CRXGate,
+        CRYGate,
+        CRZGate,
         RZZGate,
         CXGate,
         CZGate,

--- a/inconspiquous/transforms/canonicalization/gate.py
+++ b/inconspiquous/transforms/canonicalization/gate.py
@@ -34,23 +34,3 @@ class DynRotationGateToRotationPattern(RewritePattern):
             rewriter.replace_matched_op(
                 gate.ConstantGateOp(self.rot_gate(op.angle.owner.angle))
             )
-
-
-class ControlOpFoldPattern(RewritePattern):
-    """
-    Converts the control of some constant gates to their constant controlled variants.
-    """
-
-    @op_type_rewrite_pattern
-    def match_and_rewrite(self, op: gate.ControlOp, rewriter: PatternRewriter):
-        if not isinstance(op.gate.owner, gate.ConstantGateOp):
-            return
-        match op.gate.owner.gate:
-            case gate.XGate():
-                rewriter.replace_matched_op(gate.ConstantGateOp(gate.CXGate()))
-            case gate.ZGate():
-                rewriter.replace_matched_op(gate.ConstantGateOp(gate.CZGate()))
-            case gate.CXGate():
-                rewriter.replace_matched_op(gate.ConstantGateOp(gate.ToffoliGate()))
-            case _:
-                return

--- a/inconspiquous/transforms/convert_qref_to_qir.py
+++ b/inconspiquous/transforms/convert_qref_to_qir.py
@@ -14,9 +14,14 @@ from xdsl.pattern_rewriter import (
 from xdsl.transforms.dead_code_elimination import DeadCodeElimination
 from inconspiquous.dialects import qref, qir, angle
 from inconspiquous.dialects.gate import (
+    CRXGate,
+    CRYGate,
+    CRZGate,
     CXGate,
     CZGate,
-    ControlOp,
+    DynCRXGate,
+    DynCRYGate,
+    DynCRZGate,
     DynRXGate,
     DynRYGate,
     DynRZGate,
@@ -145,6 +150,33 @@ class QRefGateToQIRPattern(RewritePattern):
                         qir.RZOp(const, op.ins[0]),
                     )
                 )
+            case CRXGate():
+                rewriter.replace_matched_op(
+                    (
+                        const := arith.ConstantOp(
+                            FloatAttr(op.gate.angle.as_float(), type=Float64Type())
+                        ),
+                        qir.CRXOp(const, op.ins[0], op.ins[1]),
+                    )
+                )
+            case CRYGate():
+                rewriter.replace_matched_op(
+                    (
+                        const := arith.ConstantOp(
+                            FloatAttr(op.gate.angle.as_float(), type=Float64Type())
+                        ),
+                        qir.CRYOp(const, op.ins[0], op.ins[1]),
+                    )
+                )
+            case CRZGate():
+                rewriter.replace_matched_op(
+                    (
+                        const := arith.ConstantOp(
+                            FloatAttr(op.gate.angle.as_float(), type=Float64Type())
+                        ),
+                        qir.CRZOp(const, op.ins[0], op.ins[1]),
+                    )
+                )
             case RZZGate():
                 rewriter.replace_matched_op(
                     (
@@ -162,28 +194,22 @@ class QRefDynGateToQIRPattern(RewritePattern):
     @op_type_rewrite_pattern
     def match_and_rewrite(self, op: qref.DynGateOp, rewriter: PatternRewriter):
         gate_op = op.gate.owner
-        control = False
-        if isinstance(gate_op, ControlOp):
-            control = True
-            gate_op = gate_op.gate.owner
 
         match gate_op:
             case DynRXGate():
-                rewriter.replace_matched_op(
-                    (qir.CRXOp if control else qir.RXOp)(gate_op.angle, *op.ins)
-                )
+                rewriter.replace_matched_op(qir.RXOp(gate_op.angle, *op.ins))
             case DynRYGate():
-                rewriter.replace_matched_op(
-                    (qir.CRYOp if control else qir.RYOp)(gate_op.angle, *op.ins)
-                )
+                rewriter.replace_matched_op(qir.RYOp(gate_op.angle, *op.ins))
             case DynRZGate():
-                rewriter.replace_matched_op(
-                    (qir.CRZOp if control else qir.RZOp)(gate_op.angle, *op.ins)
-                )
+                rewriter.replace_matched_op(qir.RZOp(gate_op.angle, *op.ins))
+            case DynCRXGate():
+                rewriter.replace_matched_op(qir.CRXOp(gate_op.angle, *op.ins))
+            case DynCRYGate():
+                rewriter.replace_matched_op(qir.CRYOp(gate_op.angle, *op.ins))
+            case DynCRZGate():
+                rewriter.replace_matched_op(qir.CRZOp(gate_op.angle, *op.ins))
             case DynRZZGate():
-                if control:
-                    return
-                rewriter.replace_matched_op((qir.RZZOp)(gate_op.angle, *op.ins))
+                rewriter.replace_matched_op(qir.RZZOp(gate_op.angle, *op.ins))
             case _:
                 return
 

--- a/tests/filecheck/bench/ipe.mlir
+++ b/tests/filecheck/bench/ipe.mlir
@@ -22,7 +22,7 @@ func.func @ipe(%theta: !angle.type, %m: i64) -> !angle.type {
 
     %angle = angle.scale %theta, %factor
     %rx = gate.dyn_rx<%angle>
-    %crx = gate.control %rx : !gate.type<1>
+    %crx = gate.dyn_crx<%angle>
     %a_2, %q_2 = qssa.dyn_gate<%crx> %a_1, %q_1
 
     %z = gate.dyn_rz<%phi>

--- a/tests/filecheck/bench/qml.mlir
+++ b/tests/filecheck/bench/qml.mlir
@@ -7,14 +7,14 @@ func.func @qml(%ql: !qu.bit, %qo: !qu.bit, %w: !angle.type, %b: !angle.type) -> 
   %bn = angle.negate %b
 
   %rxw = gate.dyn_rx<%w>
-  %crxw = gate.control %rxw : !gate.type<1>
+  %crxw = gate.dyn_crx<%w>
 
   %rxb = gate.dyn_rx<%b>
 
   %rxbn = gate.dyn_rx<%bn>
 
   %rxwn = gate.dyn_rx<%wn>
-  %crxwn = gate.control %rxwn : !gate.type<1>
+  %crxwn = gate.dyn_crx<%wn>
 
   %ql_res, %qo_res = scf.while(%ql_1 = %ql, %qo_1 = %qo)
     : (!qu.bit, !qu.bit) -> (!qu.bit, !qu.bit) {

--- a/tests/filecheck/bench/rwpe.mlir
+++ b/tests/filecheck/bench/rwpe.mlir
@@ -34,7 +34,7 @@ func.func @rwpe(%mu0 : !angle.type, %sigma0 : f64, %theta : !angle.type, %iter: 
 
     %angle2 = angle.scale %theta, %t
     %rz2 = gate.dyn_rz<%angle2>
-    %crz = gate.control %rz2 : !gate.type<1>
+    %crz = gate.dyn_crz<%angle2>
     %a_3, %q_2 = qssa.dyn_gate<%crz> %a_2, %q_1
 
     %a_4 = qssa.gate<#gate.h> %a_3

--- a/tests/filecheck/dialects/gate/canonicalize.mlir
+++ b/tests/filecheck/dialects/gate/canonicalize.mlir
@@ -53,30 +53,3 @@
 %g = gate.dyn_rzz<%phi>
 
 "test.op"(%g) : (!gate.type<2>) -> ()
-
-// -----
-
-%g = gate.constant #gate.x
-
-%g1 = gate.control %g : !gate.type<1>
-// CHECK: [[out:%.*]] = gate.constant #gate.cx
-// CHECK-NEXT: "test.op"([[out]])
-"test.op"(%g1) : (!gate.type<2>) -> ()
-
-// -----
-
-%g = gate.constant #gate.z
-
-%g1 = gate.control %g : !gate.type<1>
-// CHECK: [[out:%.*]] = gate.constant #gate.cz
-// CHECK-NEXT: "test.op"([[out]])
-"test.op"(%g1) : (!gate.type<2>) -> ()
-
-// -----
-
-%g = gate.constant #gate.cx
-
-%g1 = gate.control %g : !gate.type<2>
-// CHECK: [[out:%.*]] = gate.constant #gate.toffoli
-// CHECK-NEXT: "test.op"([[out]])
-"test.op"(%g1) : (!gate.type<3>) -> ()

--- a/tests/filecheck/dialects/gate/control_types.mlir
+++ b/tests/filecheck/dialects/gate/control_types.mlir
@@ -1,7 +1,0 @@
-// RUN: quopt %s --verify-diagnostics | filecheck %s
-
-%g = gate.constant #gate.h
-
-// CHECK: result 'out' at position 0 does not verify
-// CHECK-NEXT: integer 1 expected from int variable 'I', but got 0
-"gate.control"(%g) : (!gate.type<1>) -> !gate.type<1>

--- a/tests/filecheck/dialects/gate/ops.mlir
+++ b/tests/filecheck/dialects/gate/ops.mlir
@@ -37,6 +37,15 @@
 "test.op"() {gate = #gate.j<pi>} : () -> ()
 // CHECK-NEXT: "test.op"() {gate = #gate.j<pi>} : () -> ()
 
+"test.op"() {gate = #gate.crx<pi>} : () -> ()
+// CHECK-NEXT: "test.op"() {gate = #gate.crx<pi>} : () -> ()
+
+"test.op"() {gate = #gate.cry<pi>} : () -> ()
+// CHECK-NEXT: "test.op"() {gate = #gate.cry<pi>} : () -> ()
+
+"test.op"() {gate = #gate.crz<pi>} : () -> ()
+// CHECK-NEXT: "test.op"() {gate = #gate.crz<pi>} : () -> ()
+
 "test.op"() {gate = #gate.rzz<pi>} : () -> ()
 // CHECK-NEXT: "test.op"() {gate = #gate.rzz<pi>} : () -> ()
 
@@ -95,10 +104,18 @@
 // CHECK-GENERIC: %{{.*}} = "gate.dyn_j"(%phi) : (!angle.type) -> !gate.type<1>
 %7 = gate.dyn_j<%phi>
 
+// CHECK: %{{.*}} = gate.dyn_crx<%phi>
+// CHECK-GENERIC: %{{.*}} = "gate.dyn_crx"(%phi) : (!angle.type) -> !gate.type<2>
+%8 = gate.dyn_crx<%phi>
+
+// CHECK: %{{.*}} = gate.dyn_cry<%phi>
+// CHECK-GENERIC: %{{.*}} = "gate.dyn_cry"(%phi) : (!angle.type) -> !gate.type<2>
+%9 = gate.dyn_cry<%phi>
+
+// CHECK: %{{.*}} = gate.dyn_crz<%phi>
+// CHECK-GENERIC: %{{.*}} = "gate.dyn_crz"(%phi) : (!angle.type) -> !gate.type<2>
+%10 = gate.dyn_crz<%phi>
+
 // CHECK: %{{.*}} = gate.dyn_rzz<%phi>
 // CHECK-GENERIC: %{{.*}} = "gate.dyn_rzz"(%phi) : (!angle.type) -> !gate.type<2>
-%8 = gate.dyn_rzz<%phi>
-
-// CHECK: %{{.*}} = gate.control %4 : !gate.type<1>
-// CHECK-GENERIC: %{{.*}} = "gate.control"(%4) : (!gate.type<1>) -> !gate.type<2>
-%9 = gate.control %4 : !gate.type<1>
+%11 = gate.dyn_rzz<%phi>

--- a/tests/filecheck/transforms/convert_qref_to_qir.mlir
+++ b/tests/filecheck/transforms/convert_qref_to_qir.mlir
@@ -39,6 +39,19 @@ qref.gate<#gate.ry<0.5pi>> %q1
 // CHECK-NEXT: qir.rz<[[angle3]]> %q1
 qref.gate<#gate.rz<0.5pi>> %q1
 
+// CHECK-NEXT: [[angle:%.*]] = arith.constant
+// CHECK-NEXT: qir.crx<[[angle]]> %q1, %q2
+qref.gate<#gate.crx<0.5pi>> %q1, %q2
+// CHECK-NEXT: [[angle2:%.*]] = arith.constant
+// CHECK-NEXT: qir.cry<[[angle2]]> %q1, %q2
+qref.gate<#gate.cry<0.5pi>> %q1, %q2
+// CHECK-NEXT: [[angle3:%.*]] = arith.constant
+// CHECK-NEXT: qir.crz<[[angle3]]> %q1, %q2
+qref.gate<#gate.crz<0.5pi>> %q1, %q2
+// CHECK-NEXT: [[angle3:%.*]] = arith.constant
+// CHECK-NEXT: qir.rzz<[[angle3]]> %q1, %q2
+qref.gate<#gate.rzz<0.5pi>> %q1, %q2
+
 // CHECK-NEXT: [[angle4:%.*]] = arith.constant
 %a = angle.constant<0.5pi>
 // CHECK-NEXT: [[angle5:%.*]] = arith.negf [[angle4]]
@@ -67,21 +80,21 @@ qref.dyn_gate<%ry> %q0
 // CHECK-NEXT: qir.rz<[[angle8]]> %q0
 qref.dyn_gate<%rz> %q0
 
-%rzz = gate.dyn_rzz<%add>
-// CHECK-NEXT: qir.rzz<[[angle9]]> %q0, %q1
-qref.dyn_gate<%rzz> %q0, %q1
-
-%crx = gate.control %rx : !gate.type<1>
+%crx = gate.dyn_crx<%a>
 // CHECK-NEXT: qir.crx<[[angle4]]> %q0, %q1
 qref.dyn_gate<%crx> %q0, %q1
 
-%cry = gate.control %ry : !gate.type<1>
+%cry = gate.dyn_cry<%negate>
 // CHECK-NEXT: qir.cry<[[angle5]]> %q0, %q1
 qref.dyn_gate<%cry> %q0, %q1
 
-%crz = gate.control %rz : !gate.type<1>
+%crz = gate.dyn_crz<%scale>
 // CHECK-NEXT: qir.crz<[[angle8]]> %q0, %q1
 qref.dyn_gate<%crz> %q0, %q1
+
+%rzz = gate.dyn_rzz<%add>
+// CHECK-NEXT: qir.rzz<[[angle9]]> %q0, %q1
+qref.dyn_gate<%rzz> %q0, %q1
 
 // CHECK-NEXT: [[lhs:%.*]] = qir.m %q0
 // CHECK-NEXT: qir.qubit_release %q0


### PR DESCRIPTION
As pointed out in review, this operation is unsound. Luckily it was basically just a convenience and is easily replaceable.