### PR TITLE
misc: add pyright and ruff rules from upstream

### DIFF
--- a/inconspiquous/alloc.py
+++ b/inconspiquous/alloc.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+
 from xdsl.ir import ParametrizedAttribute
 
 from inconspiquous.constraints import SizedAttribute

--- a/inconspiquous/constraints.py
+++ b/inconspiquous/constraints.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Mapping
+
 from typing_extensions import TypeVar
 from xdsl.ir import Attribute, VerifyException
 from xdsl.irdl import (

--- a/inconspiquous/dialects/angle.py
+++ b/inconspiquous/dialects/angle.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import math
-from xdsl.interfaces import HasFolderInterface, HasCanonicalizationPatternsInterface
+
+from xdsl.dialects.builtin import FloatData, i1
+from xdsl.interfaces import HasCanonicalizationPatternsInterface, HasFolderInterface
 from xdsl.ir import Dialect, Operation, ParametrizedAttribute, SSAValue, TypeAttribute
 from xdsl.irdl import (
     IRDLOperation,
@@ -12,7 +14,6 @@ from xdsl.irdl import (
     result_def,
     traits_def,
 )
-from xdsl.dialects.builtin import FloatData, i1
 from xdsl.parser import AttrParser, Float64Type
 from xdsl.pattern_rewriter import RewritePattern
 from xdsl.printer import Printer

--- a/inconspiquous/dialects/gate.py
+++ b/inconspiquous/dialects/gate.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from typing import ClassVar, Literal
 
 from xdsl.dialects.builtin import (
-    IntAttr,
     AnyFloatConstr,
-    i1,
+    IntAttr,
+    IntAttrConstraint,
     IntegerType,
+    i1,
 )
 from xdsl.interfaces import HasCanonicalizationPatternsInterface, HasFolderInterface
 from xdsl.ir import (
@@ -18,11 +20,11 @@ from xdsl.ir import (
 )
 from xdsl.irdl import (
     AnyInt,
-    BaseAttr,
     AttrConstraint,
-    IRDLOperation,
+    BaseAttr,
     IntConstraint,
     IntVarConstraint,
+    IRDLOperation,
     ParamAttrConstraint,
     VarConstraint,
     base,
@@ -38,16 +40,15 @@ from xdsl.parser import AttrParser
 from xdsl.pattern_rewriter import RewritePattern
 from xdsl.printer import Printer
 from xdsl.traits import ConstantLike, Pure
-from xdsl.dialects.builtin import IntAttrConstraint
 
+from inconspiquous.constraints import SizedAttributeConstraint
 from inconspiquous.dialects.angle import AngleAttr, AngleType
 from inconspiquous.gates import (
     GateAttr,
     SingleQubitCliffordGate,
-    TwoQubitCliffordGate,
     SingleQubitGate,
+    TwoQubitCliffordGate,
 )
-from inconspiquous.constraints import SizedAttributeConstraint
 from inconspiquous.gates.core import (
     CliffordGateAttr,
     PauliGate,

--- a/inconspiquous/dialects/measurement.py
+++ b/inconspiquous/dialects/measurement.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
+
 from typing import ClassVar
 
+from xdsl.dialects.builtin import IntAttr, IntAttrConstraint
 from xdsl.interfaces import HasCanonicalizationPatternsInterface, HasFolderInterface
 from xdsl.ir import Dialect, Operation, ParametrizedAttribute, SSAValue, TypeAttribute
 from xdsl.irdl import (
     AnyInt,
-    BaseAttr,
     AttrConstraint,
-    IRDLOperation,
+    BaseAttr,
     IntConstraint,
     IntVarConstraint,
+    IRDLOperation,
     ParamAttrConstraint,
     irdl_attr_definition,
     irdl_op_definition,
@@ -21,11 +23,11 @@ from xdsl.irdl import (
 from xdsl.parser import AttrParser
 from xdsl.pattern_rewriter import RewritePattern
 from xdsl.printer import Printer
-from inconspiquous.measurement import MeasurementAttr
-from xdsl.dialects.builtin import IntAttr, IntAttrConstraint
 from xdsl.traits import ConstantLike, Pure
+
 from inconspiquous.constraints import SizedAttributeConstraint
 from inconspiquous.dialects.angle import AngleAttr, AngleType
+from inconspiquous.measurement import MeasurementAttr
 
 
 @irdl_attr_definition

--- a/inconspiquous/dialects/prob.py
+++ b/inconspiquous/dialects/prob.py
@@ -1,6 +1,7 @@
-from typing import ClassVar, Sequence
-from typing_extensions import Self
+from collections.abc import Sequence
+from typing import ClassVar
 
+from typing_extensions import Self
 from xdsl.dialects.builtin import i1
 from xdsl.interfaces import HasCanonicalizationPatternsInterface
 from xdsl.ir import (
@@ -25,11 +26,11 @@ from xdsl.parser import (
     Float64Type,
     FloatAttr,
     IntegerType,
+    Parser,
     UnresolvedOperand,
 )
-from xdsl.parser import Parser
-from xdsl.printer import Printer
 from xdsl.pattern_rewriter import RewritePattern
+from xdsl.printer import Printer
 
 
 @irdl_op_definition
@@ -115,9 +116,9 @@ class FinSuppOp(IRDLOperation, HasCanonicalizationPatternsInterface):
     @classmethod
     def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
         from inconspiquous.transforms.canonicalization.prob import (
-            FinSuppTrivial,
-            FinSuppRemoveCase,
             FinSuppDuplicate,
+            FinSuppRemoveCase,
+            FinSuppTrivial,
         )
 
         return (FinSuppTrivial(), FinSuppRemoveCase(), FinSuppDuplicate())

--- a/inconspiquous/dialects/qec.py
+++ b/inconspiquous/dialects/qec.py
@@ -1,5 +1,6 @@
 from xdsl.ir import Dialect
 from xdsl.irdl import irdl_attr_definition
+
 from inconspiquous.gates import GateAttr
 
 

--- a/inconspiquous/dialects/qir.py
+++ b/inconspiquous/dialects/qir.py
@@ -1,5 +1,7 @@
 from abc import ABC, abstractmethod
+
 from xdsl.dialects import llvm
+from xdsl.dialects.builtin import Float64Type, i1
 from xdsl.ir import Dialect, Operation, ParametrizedAttribute, SSAValue, TypeAttribute
 from xdsl.irdl import (
     IRDLOperation,
@@ -8,7 +10,6 @@ from xdsl.irdl import (
     operand_def,
     result_def,
 )
-from xdsl.dialects.builtin import Float64Type, i1
 
 
 @irdl_attr_definition

--- a/inconspiquous/dialects/qref.py
+++ b/inconspiquous/dialects/qref.py
@@ -1,30 +1,31 @@
 from typing import ClassVar
+
 from xdsl.dialects.builtin import i1
 from xdsl.interfaces import HasCanonicalizationPatternsInterface
-from xdsl.ir import Dialect, Operation, SSAValue, Block, Region
+from xdsl.ir import Block, Dialect, Operation, Region, SSAValue
 from xdsl.irdl import (
     AnyInt,
-    IRDLOperation,
     IntVarConstraint,
+    IRDLOperation,
     RangeOf,
+    eq,
     irdl_op_definition,
     operand_def,
     prop_def,
+    region_def,
+    result_def,
     traits_def,
     var_operand_def,
-    eq,
     var_result_def,
-    result_def,
-    region_def,
 )
-from xdsl.traits import IsTerminator, HasParent
 from xdsl.pattern_rewriter import RewritePattern
+from xdsl.traits import HasParent, IsTerminator
 
+from inconspiquous.constraints import SizedAttributeConstraint
 from inconspiquous.dialects.gate import GateType
 from inconspiquous.dialects.measurement import CompBasisMeasurementAttr, MeasurementType
-from inconspiquous.gates import GateAttr
 from inconspiquous.dialects.qu import BitType
-from inconspiquous.constraints import SizedAttributeConstraint
+from inconspiquous.gates import GateAttr
 from inconspiquous.measurement import MeasurementAttr
 
 
@@ -75,8 +76,8 @@ class DynGateOp(IRDLOperation, HasCanonicalizationPatternsInterface):
     @classmethod
     def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
         from inconspiquous.transforms.canonicalization.qref import (
-            DynGateConst,
             DynGateCompose,
+            DynGateConst,
         )
 
         return (DynGateConst(), DynGateCompose())

--- a/inconspiquous/dialects/qssa.py
+++ b/inconspiquous/dialects/qssa.py
@@ -1,30 +1,31 @@
 from typing import ClassVar
+
 from xdsl.dialects.builtin import i1
 from xdsl.interfaces import HasCanonicalizationPatternsInterface
-from xdsl.ir import Dialect, Operation, SSAValue, Block, Region
+from xdsl.ir import Block, Dialect, Operation, Region, SSAValue
 from xdsl.irdl import (
     AnyInt,
-    IRDLOperation,
     IntVarConstraint,
+    IRDLOperation,
     RangeOf,
+    eq,
     irdl_op_definition,
     operand_def,
     prop_def,
+    region_def,
+    result_def,
     traits_def,
     var_operand_def,
     var_result_def,
-    result_def,
-    region_def,
-    eq,
 )
-from xdsl.traits import IsTerminator, HasParent
 from xdsl.pattern_rewriter import RewritePattern
+from xdsl.traits import HasParent, IsTerminator
 
+from inconspiquous.constraints import SizedAttributeConstraint
 from inconspiquous.dialects.gate import GateType
 from inconspiquous.dialects.measurement import CompBasisMeasurementAttr, MeasurementType
-from inconspiquous.gates import GateAttr
 from inconspiquous.dialects.qu import BitType
-from inconspiquous.constraints import SizedAttributeConstraint
+from inconspiquous.gates import GateAttr
 from inconspiquous.measurement import MeasurementAttr
 
 
@@ -81,8 +82,8 @@ class DynGateOp(IRDLOperation, HasCanonicalizationPatternsInterface):
     @classmethod
     def get_canonicalization_patterns(cls) -> tuple[RewritePattern, ...]:
         from inconspiquous.transforms.canonicalization.qssa import (
-            DynGateConst,
             DynGateCompose,
+            DynGateConst,
         )
 
         return (DynGateConst(), DynGateCompose())

--- a/inconspiquous/dialects/qu.py
+++ b/inconspiquous/dialects/qu.py
@@ -5,13 +5,13 @@ from xdsl.ir import (
     Dialect,
     Operation,
     ParametrizedAttribute,
-    TypeAttribute,
     SSAValue,
+    TypeAttribute,
 )
 from xdsl.irdl import (
     AnyInt,
-    IRDLOperation,
     IntVarConstraint,
+    IRDLOperation,
     ParamAttrConstraint,
     RangeOf,
     eq,
@@ -23,9 +23,9 @@ from xdsl.irdl import (
     var_operand_def,
     var_result_def,
 )
-from xdsl.utils.exceptions import VerifyException
 from xdsl.parser import AttrParser
 from xdsl.printer import Printer
+from xdsl.utils.exceptions import VerifyException
 
 from inconspiquous.alloc import AllocAttr
 from inconspiquous.constraints import SizedAttributeConstraint

--- a/inconspiquous/measurement.py
+++ b/inconspiquous/measurement.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+
 from xdsl.ir import ParametrizedAttribute
 
 from inconspiquous.constraints import SizedAttribute

--- a/inconspiquous/tools/gui.py
+++ b/inconspiquous/tools/gui.py
@@ -1,4 +1,5 @@
 import argparse
+
 from xdsl.interactive.app import InputApp
 
 from inconspiquous.dialects import get_all_dialects

--- a/inconspiquous/tools/quopt_main.py
+++ b/inconspiquous/tools/quopt_main.py
@@ -1,6 +1,7 @@
+from xdsl.xdsl_opt_main import xDSLOptMain
+
 from inconspiquous.dialects import get_all_dialects
 from inconspiquous.transforms import get_all_passes
-from xdsl.xdsl_opt_main import xDSLOptMain
 
 
 class QuoptMain(xDSLOptMain):

--- a/inconspiquous/transforms/canonicalization/gate.py
+++ b/inconspiquous/transforms/canonicalization/gate.py
@@ -5,6 +5,7 @@ from xdsl.pattern_rewriter import (
     op_type_rewrite_pattern,
 )
 from xdsl.transforms.canonicalization_patterns.utils import const_evaluate_operand
+
 from inconspiquous.dialects import gate
 from inconspiquous.dialects.angle import ConstantAngleOp
 

--- a/inconspiquous/transforms/canonicalization/qref.py
+++ b/inconspiquous/transforms/canonicalization/qref.py
@@ -6,7 +6,7 @@ from xdsl.pattern_rewriter import (
 
 from inconspiquous.dialects.gate import ComposeGateOp, ConstantGateOp, IdentityGate
 from inconspiquous.dialects.measurement import ConstantMeasurementOp
-from inconspiquous.dialects.qref import DynMeasureOp, GateOp, DynGateOp, MeasureOp
+from inconspiquous.dialects.qref import DynGateOp, DynMeasureOp, GateOp, MeasureOp
 
 
 class DynGateConst(RewritePattern):

--- a/inconspiquous/transforms/canonicalization/qssa.py
+++ b/inconspiquous/transforms/canonicalization/qssa.py
@@ -6,7 +6,7 @@ from xdsl.pattern_rewriter import (
 
 from inconspiquous.dialects.gate import ComposeGateOp, ConstantGateOp, IdentityGate
 from inconspiquous.dialects.measurement import ConstantMeasurementOp
-from inconspiquous.dialects.qssa import DynMeasureOp, GateOp, MeasureOp, DynGateOp
+from inconspiquous.dialects.qssa import DynGateOp, DynMeasureOp, GateOp, MeasureOp
 
 
 class DynGateConst(RewritePattern):

--- a/inconspiquous/transforms/convert_qir_to_llvm.py
+++ b/inconspiquous/transforms/convert_qir_to_llvm.py
@@ -1,11 +1,11 @@
+from xdsl.dialects import llvm
 from xdsl.ir import dataclass, field
 from xdsl.parser import Context, ModuleOp
 from xdsl.passes import ModulePass
-from xdsl.dialects import llvm
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,
-    PatternRewriteWalker,
     PatternRewriter,
+    PatternRewriteWalker,
     RewritePattern,
     TypeConversionPattern,
     attr_type_rewrite_pattern,

--- a/inconspiquous/transforms/convert_qref_to_qir.py
+++ b/inconspiquous/transforms/convert_qref_to_qir.py
@@ -1,18 +1,19 @@
 from xdsl.dialects import arith
-from xdsl.parser import Context, ModuleOp
 from xdsl.dialects.builtin import Float64Type, FloatAttr
+from xdsl.parser import Context, ModuleOp
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,
-    PatternRewriteWalker,
     PatternRewriter,
+    PatternRewriteWalker,
     RewritePattern,
     TypeConversionPattern,
     attr_type_rewrite_pattern,
     op_type_rewrite_pattern,
 )
 from xdsl.transforms.dead_code_elimination import DeadCodeElimination
-from inconspiquous.dialects import qref, qir, angle
+
+from inconspiquous.dialects import angle, qir, qref, qu
 from inconspiquous.dialects.gate import (
     CRXGate,
     CRYGate,
@@ -46,7 +47,6 @@ from inconspiquous.dialects.measurement import (
     XYDynMeasurementOp,
     XYMeasurementAttr,
 )
-from inconspiquous.dialects import qu
 
 
 class QRefTypeToQIRPattern(TypeConversionPattern):

--- a/inconspiquous/transforms/convert_qref_to_qssa.py
+++ b/inconspiquous/transforms/convert_qref_to_qssa.py
@@ -3,8 +3,8 @@ from xdsl.parser import Context
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,
-    PatternRewriteWalker,
     PatternRewriter,
+    PatternRewriteWalker,
     RewritePattern,
     op_type_rewrite_pattern,
 )

--- a/inconspiquous/transforms/convert_qssa_to_qref.py
+++ b/inconspiquous/transforms/convert_qssa_to_qref.py
@@ -9,7 +9,7 @@ from xdsl.pattern_rewriter import (
     op_type_rewrite_pattern,
 )
 
-from inconspiquous.dialects import qssa, qref
+from inconspiquous.dialects import qref, qssa
 
 
 class ConvertQssaGateToQrefGate(RewritePattern):

--- a/inconspiquous/transforms/convert_to_cme.py
+++ b/inconspiquous/transforms/convert_to_cme.py
@@ -3,17 +3,16 @@ from xdsl.parser import BoolAttr, Context
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,
-    PatternRewriteWalker,
     PatternRewriter,
+    PatternRewriteWalker,
     RewritePattern,
     op_type_rewrite_pattern,
 )
 
-from inconspiquous.dialects import angle, measurement
-from inconspiquous.dialects import qssa, qu
+from inconspiquous.dialects import angle, measurement, qssa, qu
 from inconspiquous.dialects.gate import (
-    CZGate,
     ConstantGateOp,
+    CZGate,
     DynJGate,
     IdentityGate,
     JGate,
@@ -21,7 +20,13 @@ from inconspiquous.dialects.gate import (
 )
 
 """
-CME is a normal form for MBQC patterns, see https://en.wikipedia.org/wiki/One-way_quantum_computer#CME_pattern which uses only entanglement operations, measurement, and classical controlled correction. This pass rewrites operations to be of this form.
+CME is a normal form for MBQC patterns, which uses only
+- entanglement operations,
+- measurement,
+- and classical controlled correction.
+see https://en.wikipedia.org/wiki/One-way_quantum_computer#CME_pattern
+
+This pass rewrites operations to be of this form.
 
 As CZ gates are legal in CME, this pass only rewrites J gates into CME form.
 """

--- a/inconspiquous/transforms/convert_to_cz_j.py
+++ b/inconspiquous/transforms/convert_to_cz_j.py
@@ -2,8 +2,8 @@ from xdsl.dialects import builtin
 from xdsl.parser import Context
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
-    PatternRewriteWalker,
     PatternRewriter,
+    PatternRewriteWalker,
     RewritePattern,
     op_type_rewrite_pattern,
 )

--- a/inconspiquous/transforms/convert_to_mbqc.py
+++ b/inconspiquous/transforms/convert_to_mbqc.py
@@ -1,5 +1,5 @@
-from xdsl.dialects import builtin
 from xdsl.context import Context
+from xdsl.dialects import builtin
 from xdsl.passes import ModulePass
 from xdsl.transforms.canonicalize import CanonicalizePass
 from xdsl.transforms.common_subexpression_elimination import (
@@ -8,8 +8,8 @@ from xdsl.transforms.common_subexpression_elimination import (
 
 from inconspiquous.transforms.convert_to_cme import ToCMEPass
 from inconspiquous.transforms.mbqc_legalize import MBQCLegalize
-from inconspiquous.transforms.xzs.convert_to_xzs import ConvertToXZS
 from inconspiquous.transforms.xzs.commute import XZCommute
+from inconspiquous.transforms.xzs.convert_to_xzs import ConvertToXZS
 from inconspiquous.transforms.xzs.select import XZSSelect
 
 

--- a/inconspiquous/transforms/flip_coins.py
+++ b/inconspiquous/transforms/flip_coins.py
@@ -1,17 +1,18 @@
+import random
+
+from xdsl.dialects import arith, builtin
 from xdsl.ir import dataclass, field
 from xdsl.parser import Context, IntegerAttr, IntegerType
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,
-    PatternRewriteWalker,
     PatternRewriter,
+    PatternRewriteWalker,
     RewritePattern,
     op_type_rewrite_pattern,
 )
-from xdsl.dialects import arith, builtin
-from inconspiquous.dialects.prob import BernoulliOp, UniformOp
 
-import random
+from inconspiquous.dialects.prob import BernoulliOp, UniformOp
 
 
 @dataclass

--- a/inconspiquous/transforms/inline_circuits.py
+++ b/inconspiquous/transforms/inline_circuits.py
@@ -6,13 +6,13 @@ from xdsl.dialects import builtin
 from xdsl.parser import Context
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
-    PatternRewriteWalker,
     PatternRewriter,
+    PatternRewriteWalker,
     RewritePattern,
     op_type_rewrite_pattern,
 )
 
-from inconspiquous.dialects.qssa import DynGateOp, CircuitOp, ReturnOp
+from inconspiquous.dialects.qssa import CircuitOp, DynGateOp, ReturnOp
 
 
 class InlineCircuitPattern(RewritePattern):

--- a/inconspiquous/transforms/lower_dyn_gate_to_scf.py
+++ b/inconspiquous/transforms/lower_dyn_gate_to_scf.py
@@ -1,20 +1,20 @@
 from typing import cast
+
 from xdsl.builder import ImplicitBuilder
-from xdsl.dialects import arith, scf, varith
-from xdsl.dialects import builtin
-from xdsl.ir import Block, Region, SSAValue
+from xdsl.dialects import arith, builtin, scf, varith
 from xdsl.dialects.builtin import IndexType
-from xdsl.parser import DenseArrayBase, IntegerType, Context
+from xdsl.ir import Block, Region, SSAValue
+from xdsl.parser import Context, DenseArrayBase, IntegerType
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,
-    PatternRewriteWalker,
     PatternRewriter,
+    PatternRewriteWalker,
     RewritePattern,
     op_type_rewrite_pattern,
 )
 
-from inconspiquous.dialects import qssa, qref
+from inconspiquous.dialects import qref, qssa
 
 
 class LowerQSSADynGateToScfPattern(RewritePattern):

--- a/inconspiquous/transforms/lower_to_fin_supp.py
+++ b/inconspiquous/transforms/lower_to_fin_supp.py
@@ -1,16 +1,16 @@
 from xdsl.context import Context
-from xdsl.dialects import builtin
+from xdsl.dialects import arith, builtin
 from xdsl.dialects.builtin import BoolAttr
 from xdsl.ir import Operation, dataclass
+from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,
-    PatternRewriteWalker,
     PatternRewriter,
+    PatternRewriteWalker,
     RewritePattern,
     op_type_rewrite_pattern,
 )
-from xdsl.dialects import arith
-from xdsl.passes import ModulePass
+
 from inconspiquous.dialects.prob import BernoulliOp, FinSuppOp, UniformOp
 
 

--- a/inconspiquous/transforms/mbqc_legalize.py
+++ b/inconspiquous/transforms/mbqc_legalize.py
@@ -1,10 +1,10 @@
+from xdsl.context import Context
 from xdsl.dialects import builtin
 from xdsl.dialects.func import FuncOp
 from xdsl.ir import Block, Operation
-from xdsl.traits import IsTerminator
-from xdsl.context import Context
 from xdsl.passes import ModulePass
 from xdsl.rewriter import InsertPoint, Rewriter
+from xdsl.traits import IsTerminator
 from xdsl.utils.exceptions import PassFailedException
 
 from inconspiquous.dialects.angle import (
@@ -12,17 +12,17 @@ from inconspiquous.dialects.angle import (
     ConstantAngleOp,
     NegateAngleOp,
 )
-from inconspiquous.dialects.measurement import XYDynMeasurementOp, XYMeasurementAttr
-from inconspiquous.dialects.qssa import DynGateOp, DynMeasureOp, MeasureOp, GateOp
 from inconspiquous.dialects.gate import (
-    CZGate,
     ConstantGateOp,
+    CZGate,
     IdentityGate,
     XGate,
+    XZOp,
     YGate,
     ZGate,
-    XZOp,
 )
+from inconspiquous.dialects.measurement import XYDynMeasurementOp, XYMeasurementAttr
+from inconspiquous.dialects.qssa import DynGateOp, DynMeasureOp, GateOp, MeasureOp
 from inconspiquous.dialects.qu import AllocOp
 
 

--- a/inconspiquous/transforms/pauli_fusion.py
+++ b/inconspiquous/transforms/pauli_fusion.py
@@ -2,11 +2,12 @@ from xdsl.dialects import builtin
 from xdsl.parser import Context
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
-    PatternRewriteWalker,
     PatternRewriter,
+    PatternRewriteWalker,
     RewritePattern,
     op_type_rewrite_pattern,
 )
+
 from inconspiquous.dialects import qssa
 from inconspiquous.dialects.gate import XGate, YGate, ZGate
 

--- a/inconspiquous/transforms/qec/inline.py
+++ b/inconspiquous/transforms/qec/inline.py
@@ -4,17 +4,17 @@ from xdsl.dialects.arith import AndIOp, ConstantOp, OrIOp, SelectOp, XOrIOp
 from xdsl.parser import Context
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
-    PatternRewriteWalker,
     PatternRewriter,
+    PatternRewriteWalker,
     RewritePattern,
     op_type_rewrite_pattern,
 )
 from xdsl.rewriter import InsertPoint
 
 from inconspiquous.dialects.gate import (
+    ConstantGateOp,
     CXGate,
     CZGate,
-    ConstantGateOp,
     HadamardGate,
     IdentityGate,
     XGate,

--- a/inconspiquous/transforms/randomized_comp.py
+++ b/inconspiquous/transforms/randomized_comp.py
@@ -1,6 +1,7 @@
 from xdsl.context import Context
 from xdsl.dialects import builtin
 from xdsl.dialects.arith import SelectOp, XOrIOp
+from xdsl.dialects.builtin import i1
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,
@@ -9,12 +10,11 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
-from xdsl.dialects.builtin import i1
 from xdsl.rewriter import InsertPoint
 
 from inconspiquous.dialects.gate import (
-    CXGate,
     ConstantGateOp,
+    CXGate,
     HadamardGate,
     IdentityGate,
     PhaseDaggerGate,
@@ -25,8 +25,8 @@ from inconspiquous.dialects.gate import (
     ZGate,
 )
 from inconspiquous.dialects.measurement import CompBasisMeasurementAttr
-from inconspiquous.dialects.qssa import DynGateOp, GateOp, MeasureOp
 from inconspiquous.dialects.prob import UniformOp
+from inconspiquous.dialects.qssa import DynGateOp, GateOp, MeasureOp
 
 
 class PadTGate(RewritePattern):

--- a/inconspiquous/transforms/xzs/commute.py
+++ b/inconspiquous/transforms/xzs/commute.py
@@ -1,5 +1,5 @@
-from xdsl.ir import Operation, SSAValue
 from xdsl.dialects import arith, builtin
+from xdsl.ir import Operation, SSAValue
 from xdsl.parser import Context
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
@@ -8,6 +8,7 @@ from xdsl.pattern_rewriter import (
     RewritePattern,
     op_type_rewrite_pattern,
 )
+
 from inconspiquous.dialects import qssa
 from inconspiquous.dialects.angle import AngleAttr, CondNegateAngleOp, ConstantAngleOp
 from inconspiquous.dialects.gate import XZOp

--- a/inconspiquous/transforms/xzs/convert_to_xzs.py
+++ b/inconspiquous/transforms/xzs/convert_to_xzs.py
@@ -4,8 +4,8 @@ from xdsl.parser import Context, IntAttr
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,
-    PatternRewriteWalker,
     PatternRewriter,
+    PatternRewriteWalker,
     RewritePattern,
     op_type_rewrite_pattern,
 )

--- a/inconspiquous/transforms/xzs/fusion.py
+++ b/inconspiquous/transforms/xzs/fusion.py
@@ -1,16 +1,16 @@
-from xdsl.dialects import builtin
-from xdsl.dialects import arith
+from xdsl.dialects import arith, builtin
 from xdsl.dialects.arith import AndIOp, XOrIOp
 from xdsl.parser import Context
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,
-    PatternRewriteWalker,
     PatternRewriter,
+    PatternRewriteWalker,
     RewritePattern,
     op_type_rewrite_pattern,
 )
 from xdsl.rewriter import InsertPoint
+
 from inconspiquous.dialects.gate import XZOp, XZSOp
 from inconspiquous.dialects.qssa import DynGateOp
 

--- a/inconspiquous/transforms/xzs/lower.py
+++ b/inconspiquous/transforms/xzs/lower.py
@@ -1,22 +1,22 @@
-from xdsl.dialects import arith, builtin
 from xdsl.context import Context
+from xdsl.dialects import arith, builtin
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,
-    PatternRewriteWalker,
     PatternRewriter,
+    PatternRewriteWalker,
     RewritePattern,
     op_type_rewrite_pattern,
 )
 
 from inconspiquous.dialects.gate import (
     ComposeGateOp,
+    ConstantGateOp,
     IdentityGate,
     PhaseGate,
     XGate,
     XZOp,
     XZSOp,
-    ConstantGateOp,
     YGate,
     ZGate,
 )

--- a/inconspiquous/transforms/xzs/pipeline.py
+++ b/inconspiquous/transforms/xzs/pipeline.py
@@ -1,5 +1,5 @@
-from xdsl.dialects import builtin
 from xdsl.context import Context
+from xdsl.dialects import builtin
 from xdsl.passes import ModulePass
 from xdsl.transforms.canonicalize import CanonicalizePass
 from xdsl.transforms.common_subexpression_elimination import (
@@ -7,8 +7,8 @@ from xdsl.transforms.common_subexpression_elimination import (
 )
 
 from inconspiquous.transforms.xzs.convert_to_xzs import ConvertToXZS
-from inconspiquous.transforms.xzs.lower import LowerXZSToSelect
 from inconspiquous.transforms.xzs.fusion import XZSFusion
+from inconspiquous.transforms.xzs.lower import LowerXZSToSelect
 from inconspiquous.transforms.xzs.select import XZSSelect
 
 

--- a/inconspiquous/transforms/xzs/select.py
+++ b/inconspiquous/transforms/xzs/select.py
@@ -1,11 +1,11 @@
 from xdsl.dialects import builtin
-from xdsl.dialects.arith import SelectOp, ConstantOp
+from xdsl.dialects.arith import ConstantOp, SelectOp
 from xdsl.parser import Context
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (
     GreedyRewritePatternApplier,
-    PatternRewriteWalker,
     PatternRewriter,
+    PatternRewriteWalker,
     RewritePattern,
     op_type_rewrite_pattern,
 )

--- a/inconspiquous/utils/linear_walker.py
+++ b/inconspiquous/utils/linear_walker.py
@@ -1,5 +1,5 @@
-from xdsl.ir import Block, Operation, Region
 from xdsl.dialects.builtin import ModuleOp
+from xdsl.ir import Block, Operation, Region
 from xdsl.pattern_rewriter import (
     PatternRewriter,
     PatternRewriterListener,

--- a/inconspiquous/utils/qssa_builder.py
+++ b/inconspiquous/utils/qssa_builder.py
@@ -1,5 +1,6 @@
-from xdsl.ir import Operation, SSAValue
 from dataclasses import dataclass
+
+from xdsl.ir import Operation, SSAValue
 
 from inconspiquous.dialects.qssa import DynGateOp, GateOp, MeasureOp
 from inconspiquous.dialects.qu import AllocOp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,5 +36,40 @@ build-backend = "setuptools.build_meta"
 
 [tool.pyright]
 enableExperimentalFeatures = true
+reportUnnecessaryCast = true
+reportUnnecessaryIsInstance = true
+reportUnnecessaryTypeIgnoreComment = true
+enableTypeIgnoreComments = false
+reportAssertAlwaysTrue = true
+reportImportCycles = false
 typeCheckingMode = "strict"
-include = ["inconspiquous"]
+include = ["inconspiquous", "tests"]
+
+[tool.ruff]
+target-version = "py310"
+extend-include = ["*.ipynb", "*.pyi"]
+exclude = [".venv", "docs/marimo"]
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP", "PT", "TID251", "INP", "PYI"]
+ignore = [
+    "E741",   # https://beta.ruff.rs/docs/rules/ambiguous-variable-name/
+    "PT006",  # https://beta.ruff.rs/docs/rules/pytest-parametrize-names-wrong-type/
+    "PT012",  # https://beta.ruff.rs/docs/rules/pytest-raises-with-multiple-statements/
+    "PYI041", # https://docs.astral.sh/ruff/rules/redundant-numeric-union
+]
+
+[tool.ruff.lint.pycodestyle]
+# TODO: remove this setting and go to default line length of 88
+# Removing this line length results in a large number of errors for doc strings, ideally
+# these should be ignored separately.
+max-line-length = 130
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"typing.TypeVar".msg = "Use typing_extensions.TypeVar instead."
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["E501", "INP"]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10

--- a/tests/builder/test_qssa_builder.py
+++ b/tests/builder/test_qssa_builder.py
@@ -1,8 +1,8 @@
-from inconspiquous.dialects import qssa, qu, gate
+import pytest
+
+from inconspiquous.dialects import gate, qssa, qu
 from inconspiquous.dialects.gate import HadamardGate
 from inconspiquous.utils.qssa_builder import QSSABuilder
-
-import pytest
 
 
 def test_qssa_builder_alloc():
@@ -58,5 +58,5 @@ def test_double_measure():
     q = QSSABuilder.alloc()
     QSSABuilder.measure(q)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Consumed qubit was used"):
         QSSABuilder.measure(q)

--- a/tests/quopt/test_quopt.py
+++ b/tests/quopt/test_quopt.py
@@ -1,5 +1,6 @@
 from contextlib import redirect_stdout
 from io import StringIO
+
 from inconspiquous.tools.quopt_main import QuoptMain
 
 

--- a/tests/test_qir.py
+++ b/tests/test_qir.py
@@ -1,4 +1,5 @@
 from xdsl.dialects.llvm import LLVMPointerType, LLVMVoidType
+
 from inconspiquous.dialects.qir import QIR, QIROperation, QubitType, ResultType
 
 

--- a/tests/transforms/test_flip_coins.py
+++ b/tests/transforms/test_flip_coins.py
@@ -1,8 +1,7 @@
-from xdsl.dialects import arith
-from xdsl.parser import Parser
 from xdsl.context import Context
+from xdsl.dialects import arith
 from xdsl.dialects.builtin import ModuleOp
-from xdsl.parser import IntegerAttr
+from xdsl.parser import IntegerAttr, Parser
 
 from inconspiquous.dialects.prob import BernoulliOp, Prob
 from inconspiquous.transforms.flip_coins import FlipCoinsPass

--- a/tests/transforms/test_inline_circuits.py
+++ b/tests/transforms/test_inline_circuits.py
@@ -6,9 +6,9 @@ from xdsl.context import Context
 from xdsl.dialects.builtin import ModuleOp
 from xdsl.ir import Block, Region
 
-from inconspiquous.dialects.qssa import CircuitOp, ReturnOp, GateOp, DynGateOp
-from inconspiquous.dialects.qu import BitType, AllocOp
 from inconspiquous.dialects.gate import XGate, YGate, ZGate
+from inconspiquous.dialects.qssa import CircuitOp, DynGateOp, GateOp, ReturnOp
+from inconspiquous.dialects.qu import AllocOp, BitType
 from inconspiquous.transforms.inline_circuits import InlineCircuitsPass
 
 


### PR DESCRIPTION
These should have been included from the start. Should be mainly import reordering