### PR TITLE
installation: (llvm) Move to llvm 22

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
               LD_LIBRARY_PATH = "${stdenv.cc.cc.lib}/lib";
               buildInputs = [
                 uv
-                llvmPackages_20.mlir
+                llvmPackages_22.mlir
               ];
             };
           }

--- a/tests/filecheck/bench/adaptive_qec.mlir
+++ b/tests/filecheck/bench/adaptive_qec.mlir
@@ -428,7 +428,7 @@ func.func @adaptive_qec_cycle(
 // CHECK-NEXT:    %122 = phi i1 [ %80, %110 ], [ %80, %109 ], [ %80, %108 ], [ %80, %107 ], [ %10, %47 ]
 // CHECK-NEXT:    %123 = phi i1 [ %85, %110 ], [ %85, %109 ], [ %85, %108 ], [ %85, %107 ], [ %11, %47 ]
 // CHECK-NEXT:    %124 = phi i1 [ %90, %110 ], [ %90, %109 ], [ %90, %108 ], [ %90, %107 ], [ %12, %47 ]
-// CHECK-NEXT:    %125 = insertvalue { ptr, ptr, ptr, ptr, ptr, ptr, ptr, i1, i1, i1, i1, i1, i1 } undef, ptr %112, 0
+// CHECK-NEXT:    %125 = insertvalue { ptr, ptr, ptr, ptr, ptr, ptr, ptr, i1, i1, i1, i1, i1, i1 } poison, ptr %112, 0
 // CHECK-NEXT:    %126 = insertvalue { ptr, ptr, ptr, ptr, ptr, ptr, ptr, i1, i1, i1, i1, i1, i1 } %125, ptr %113, 1
 // CHECK-NEXT:    %127 = insertvalue { ptr, ptr, ptr, ptr, ptr, ptr, ptr, i1, i1, i1, i1, i1, i1 } %126, ptr %114, 2
 // CHECK-NEXT:    %128 = insertvalue { ptr, ptr, ptr, ptr, ptr, ptr, ptr, i1, i1, i1, i1, i1, i1 } %127, ptr %115, 3

--- a/tests/filecheck/bench/mbqc_cx.mlir
+++ b/tests/filecheck/bench/mbqc_cx.mlir
@@ -63,7 +63,7 @@ func.func @cx(%ctrl: !qu.bit, %tgt: !qu.bit) -> (!qu.bit, !qu.bit) {
 // CHECK-NEXT:    br label %18
 // CHECK-EMPTY:
 // CHECK-NEXT:  18:                                               ; preds = %14, %15, %17, %16
-// CHECK-NEXT:    %19 = insertvalue { ptr, ptr } undef, ptr %0, 0
+// CHECK-NEXT:    %19 = insertvalue { ptr, ptr } poison, ptr %0, 0
 // CHECK-NEXT:    %20 = insertvalue { ptr, ptr } %19, ptr %4, 1
 // CHECK-NEXT:    ret { ptr, ptr } %20
 // CHECK-NEXT:  }

--- a/tests/filecheck/bench/qaoa.mlir
+++ b/tests/filecheck/bench/qaoa.mlir
@@ -36,7 +36,7 @@ func.func @qaoa_problem(
 // CHECK-NEXT:    call void @__quantum__qis__rzz__body(double %0, ptr %4, ptr %1)
 // CHECK-NEXT:    call void @__quantum__qis__rzz__body(double %0, ptr %1, ptr %5)
 // CHECK-NEXT:    call void @__quantum__qis__rzz__body(double %0, ptr %2, ptr %5)
-// CHECK-NEXT:    %7 = insertvalue { ptr, ptr, ptr, ptr, ptr } undef, ptr %1, 0
+// CHECK-NEXT:    %7 = insertvalue { ptr, ptr, ptr, ptr, ptr } poison, ptr %1, 0
 // CHECK-NEXT:    %8 = insertvalue { ptr, ptr, ptr, ptr, ptr } %7, ptr %2, 1
 // CHECK-NEXT:    %9 = insertvalue { ptr, ptr, ptr, ptr, ptr } %8, ptr %3, 2
 // CHECK-NEXT:    %10 = insertvalue { ptr, ptr, ptr, ptr, ptr } %9, ptr %4, 3
@@ -68,7 +68,7 @@ func.func @qaoa_mixer(
 // CHECK-NEXT:    call void @__quantum__qis__rx__body(double %0, ptr %3)
 // CHECK-NEXT:    call void @__quantum__qis__rx__body(double %0, ptr %4)
 // CHECK-NEXT:    call void @__quantum__qis__rx__body(double %0, ptr %5)
-// CHECK-NEXT:    %7 = insertvalue { ptr, ptr, ptr, ptr, ptr } undef, ptr %1, 0
+// CHECK-NEXT:    %7 = insertvalue { ptr, ptr, ptr, ptr, ptr } poison, ptr %1, 0
 // CHECK-NEXT:    %8 = insertvalue { ptr, ptr, ptr, ptr, ptr } %7, ptr %2, 1
 // CHECK-NEXT:    %9 = insertvalue { ptr, ptr, ptr, ptr, ptr } %8, ptr %3, 2
 // CHECK-NEXT:    %10 = insertvalue { ptr, ptr, ptr, ptr, ptr } %9, ptr %4, 3
@@ -167,7 +167,7 @@ func.func @qaoa_ansatz(
 // CHECK-NEXT:    %47 = call ptr @__quantum__rt__result_get_one()
 // CHECK-NEXT:    %48 = call i1 @__quantum__rt__result_equal(ptr %46, ptr %47)
 // CHECK-NEXT:    call void @__quantum__rt__qubit_release(ptr %33)
-// CHECK-NEXT:    %49 = insertvalue { i1, i1, i1, i1, i1 } undef, i1 %36, 0
+// CHECK-NEXT:    %49 = insertvalue { i1, i1, i1, i1, i1 } poison, i1 %36, 0
 // CHECK-NEXT:    %50 = insertvalue { i1, i1, i1, i1, i1 } %49, i1 %39, 1
 // CHECK-NEXT:    %51 = insertvalue { i1, i1, i1, i1, i1 } %50, i1 %42, 2
 // CHECK-NEXT:    %52 = insertvalue { i1, i1, i1, i1, i1 } %51, i1 %45, 3

--- a/tests/filecheck/bench/qml.mlir
+++ b/tests/filecheck/bench/qml.mlir
@@ -64,7 +64,7 @@ func.func @qml(%ql: !qu.bit, %qo: !qu.bit, %w: !angle.type, %b: !angle.type) -> 
 // CHECK-NEXT:    br label %7
 // CHECK-EMPTY:
 // CHECK-NEXT:  17:                                               ; preds = %7
-// CHECK-NEXT:    %18 = insertvalue { ptr, ptr } undef, ptr %8, 0
+// CHECK-NEXT:    %18 = insertvalue { ptr, ptr } poison, ptr %8, 0
 // CHECK-NEXT:    %19 = insertvalue { ptr, ptr } %18, ptr %9, 1
 // CHECK-NEXT:    ret { ptr, ptr } %19
 // CHECK-NEXT:  }


### PR DESCRIPTION
Xdsl is now on llvm 22, so might as well bump it here too.
We currently only use this for `mlir-translate`